### PR TITLE
docs: colocated rework of the field-notes migration (supersedes PR #14)

### DIFF
--- a/.claude/skills/kiosk-debug/SKILL.md
+++ b/.claude/skills/kiosk-debug/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: kiosk-debug
+description: >-
+  Diagnose a running wisekiosk device that has no keyboard, no visible console and a display
+  whose correct state is a black screen. Decides which instrument to reach for — TCP-state
+  inference, a screenshot, a soak read, or a boot profile — and drives the tools/kiosk-*.sh
+  scripts behind them. Invoke when the kiosk is unreachable, blank, stale, suspected of
+  leaking memory, or slow to come up, and when a boot-time change needs measuring.
+---
+
+# Debugging a display you cannot see
+
+The device has no keyboard and no console anyone can read, and the screen itself cannot report
+its own state — [`tools/kiosk-tcp-state.sh`](../../../tools/kiosk-tcp-state.sh)'s header says
+which faults it hides. Every tool here exists to replace looking at the screen with reading
+something definite.
+
+## Which instrument answers which question
+
+| Question | Reach for | Why this one |
+|---|---|---|
+| Is the browser fetching the page at all, and did its scripts run? | [`tools/kiosk-tcp-state.sh`](../../../tools/kiosk-tcp-state.sh) | Socket state distinguishes "never connected", "fetched HTML only" and "rendering" without touching the device. Needs no access to the kiosk — run it on the host serving the page. |
+| Is the screen showing the right thing, right now? | [`tools/kiosk-screenshot.sh`](../../../tools/kiosk-screenshot.sh) | The only check that can catch a *frozen* render. Nothing process-level can. |
+| Is memory flat, or climbing over hours? | `kiosk-soak.sh --summary` on the device, via [`tools/kiosk-ssh.sh`](../../../tools/kiosk-ssh.sh) | The sampler already runs; the answer is in `/data/kiosk-soak.log`, and its own header says how to read it. |
+| Where is boot time going, and would reordering work help? | [`tools/kiosk-bootprofile.sh`](../../../tools/kiosk-bootprofile.sh) | Only source of per-window CPU/I-O and the module timeline. Costs a reboot and ~3 minutes. |
+| The device is not answering and its address is unknown | [`tools/kiosk-find.sh`](../../../tools/kiosk-find.sh) | The router's client list is DHCP leases, so a reachable host can be missing from it. |
+
+Reach for the cheapest instrument that can *fail*. TCP state and a screenshot cost seconds and
+no reboot; a boot profile costs a boot of the thing you are debugging.
+
+Every one of these opens an SSH connection to the device, so batch reads through `kiosk-ssh.sh`
+rather than issuing them one at a time; its header says what a connection costs and how it is
+reused. During a boot profile the connection is itself an instrument — see
+[`meta-wisekiosk/recipes-core/kiosk-bootprof/README.md`](../../../meta-wisekiosk/recipes-core/kiosk-bootprof/README.md).
+
+## Ordering a diagnosis
+
+1. **Is it reachable?** If not, `kiosk-find.sh` on the LAN before assuming it is down — and if
+   it answers there but not over SSH, close a stale multiplex master (`kiosk-ssh.sh <host>
+   --close`) before diagnosing anything else.
+2. **Is it rendering?** `kiosk-screenshot.sh`. A blank result and a correct-but-stale result are
+   different faults with the same appearance, which is why the script takes the device clock in
+   the same call as the pixels.
+3. **If it is not rendering, is it fetching?** `kiosk-tcp-state.sh` from the serving host
+   separates "the browser is not running" from "the page will not execute".
+4. **If it is rendering but degraded**, read the soak log before rebooting. A reboot destroys
+   the only series that could have told you what was happening.
+
+## Tips that cost real time to learn
+
+- **`pgrep -f <pattern>` matches your own command line** over SSH, so it finds your shell and
+  reports the process as running. Use `pgrep -x`, or match the binary path.
+- **Sample twice before believing a one-shot read.** One sample cannot tell a state from a
+  moment.
+- **Read `kiosk-ssh.sh`'s header before writing a probe of your own.** What it says about
+  silencing output and about exit codes is what turns a broken check into a false alarm.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,4 +1,14 @@
 #!/bin/sh
 # Same guards CI runs, so a commit cannot pass here and fail there.
 # Install with: just install-hooks
-exec tools/ci-guards.sh
+#
+# doc-image.py is not run here: it needs a populated build/ rootfs, which most
+# checkouts do not have, so it would print a skip banner on every commit. It is
+# a local gate, `just image`, run by hand after a build.
+#
+# Both checks run even when the first fails, matching `just verify`: two
+# independent findings are worth more than the first one twice.
+rc=0
+tools/ci-guards.sh || rc=1
+python3 tools/doc-links.py || rc=1
+exit $rc

--- a/.github/workflows/guards.yml
+++ b/.github/workflows/guards.yml
@@ -34,3 +34,15 @@ jobs:
 
       - name: Run repository guards
         run: tools/ci-guards.sh
+
+      # Pure stdlib, no install step. tools/doc-image.py is deliberately NOT
+      # here: it compares prose against a built rootfs, CI never builds one, and
+      # a required check that skips on every run is noise, not a gate.
+      #
+      # !cancelled(): this runs even when the guards step failed, matching the
+      # hook and `just verify` -- two independent findings are worth more than
+      # the first one twice. The job still fails if either step does, and unlike
+      # always() a cancelled run stays cancelled.
+      - name: Check Markdown cross-references
+        if: ${{ !cancelled() }}
+        run: python3 tools/doc-links.py

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,13 @@ build/
 sources/
 .kas_shell_history
 secrets.yaml
+
+# Operator notes about the physical units: serials, MACs, addresses, one-off
+# readings. Individually harmless, together a fingerprint of one network, and
+# this repository is public.
+local/
+
+# The skills under .claude/ are tracked; these two are per-checkout machine
+# state, and settings.local.json in particular carries local filesystem paths.
+.claude/settings.local.json
+.claude/scheduled_tasks.lock

--- a/Justfile
+++ b/Justfile
@@ -85,6 +85,35 @@ install-hooks:
     git config core.hooksPath .githooks
     @echo "core.hooksPath -> .githooks (pre-commit runs tools/ci-guards.sh)"
 
+# === Documentation checks ===
+
+# Both checks run even when the first fails: two independent findings are worth
+# more than the first one twice.
+[group('check')]
+[script('bash')]
+[doc("Run every documentation check")]
+verify:
+    rc=0
+    python3 tools/doc-links.py || rc=1
+    python3 tools/doc-image.py check || rc=1
+    if [ $rc -ne 0 ]; then echo; echo "verify FAILED"; fi
+    exit $rc
+
+# Cross-references in every tracked Markdown file: [text](path), #anchors, and
+# section-name refs must resolve.
+[group('check')]
+[doc("Check that every tracked Markdown cross-reference resolves")]
+links:
+    python3 tools/doc-links.py
+
+# What the prose says the image ships, against what it ships. Needs a populated
+# build/ rootfs and is therefore local-only -- CI never builds, so wiring it
+# into a required check would mean a permanently skipping gate.
+[group('check')]
+[doc("Check docs against what the built image ships (skips if unbuilt)")]
+image:
+    python3 tools/doc-image.py check
+
 # Write per-site config to a device's /data. The image carries none of it.
 [group('provision')]
 [doc("Provision a reachable device's /data from secrets.yaml")]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Updates are RAUC A/B over U-Boot, delivered over the LAN. Site configuration —
 hostname, machine-id — is **never** in the image; it is written to the device's `/data` partition by
 provisioning and read at runtime.
 
+The page the kiosk shows is served by a separate system elsewhere on the LAN that this repository
+neither builds nor deploys. Only its URL enters here, as site config.
+
 > ## Attribution
 >
 > This project builds on [jsmith212/meta-autonomos](https://github.com/jsmith212/meta-autonomos),
@@ -46,14 +49,17 @@ meta-wisekiosk/                    <- the repository (project scaffolding)
 │   ├── classes/
 │   └── recipes-*/
 ├── Justfile, justfiles/           build, OTA and device commands
-├── tools/                         provisioning, chunked bundle delivery, CI guards
-├── docs/                          layers-and-kas.md
+├── tools/                         provisioning, bundle delivery, device debugging, doc gate, CI guards
+├── docs/                          layers-and-kas.md, issue_investigation/
 └── sources/                       gitignored; everything kas fetches lands here
 ```
 
 Nothing outside `meta-wisekiosk/` is read by BitBake. Nothing inside it is read by anything else.
 If you are new to Yocto, read **[docs/layers-and-kas.md](docs/layers-and-kas.md)** — it explains what
 a layer is, what kas does with these files, and why the two patches cannot be bbappends.
+
+Every change that was acted on is documented at the recipe carrying it; the per-issue investigations
+behind those changes are indexed in **[docs/README.md](docs/README.md)**.
 
 ## Quick start
 
@@ -102,8 +108,10 @@ just kiosk-rollback # if the new slot comes up wrong
 ```
 
 `kiosk-preflight` refuses a delivery that cannot work — wrong slot size, stale bundle, no room on
-`/data` — before spending twenty-five minutes transferring it. The transfer is chunked because this
-board wedges on sustained SDIO traffic in either direction; a plain `scp` of the bundle hangs it.
+`/data` — before spending twenty-five minutes transferring it. The chunked transfer is a superseded
+workaround: the root cause is fixed by the clock cap in
+[`kiosk-cpufreq`](meta-wisekiosk/recipes-core/kiosk-cpufreq/kiosk-cpufreq_1.0.bb), and removing the
+chunking is tracked by issue #29 remove chunked bundle delivery.
 
 ## Configuration and secrets
 
@@ -121,6 +129,10 @@ those value names becomes a build input again in the kas config, the layer, `inc
 **kas merges `local_conf_header` by block name and the top-level file wins**, so a block named the
 same as one in `kiosk-zero-w.yaml` is discarded silently — no warning, no error, variables that never
 reach bitbake. Keep the keys unique.
+
+Losing `/data` is a re-provisioning, not a restore. `tools/provision.sh` writes the site config
+again from `secrets.yaml`, and a machine-id not recorded there comes back as a new one; there is no
+multi-GB image to put back.
 
 ## Upstream fixes
 
@@ -164,5 +176,8 @@ Two more fixes belong upstream but did not need a patch, because a downstream la
   a bad update rolls back, or that a slow-but-healthy boot does *not* trigger one.
 - **Signing keys are upstream's development keys.** Production needs its own, and the decision is
   one-way: a device trusts only the keyring baked into its rootfs.
+- **Root login is unauthenticated.** The image carries `debug-tweaks`, so root has an empty password.
+  Deferred deliberately while a second device still depends on unauthenticated access; tracked as
+  issue #7 debug-tweaks empty root password, which carries the detail.
 - **Screen blanking over a long idle is unverified.** `-s 0 -dpms -nocursor` moved from lightdm into
   the kiosk unit; that failure only appears after ~20 minutes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,17 @@
+# docs
+
+| Document | What question it answers |
+|---|---|
+| [`layers-and-kas.md`](layers-and-kas.md) | How does a tree of YAML and recipes become an image, for someone who has not used Yocto? |
+| [`issue_investigation/boot_cpu_saturation/`](issue_investigation/boot_cpu_saturation/README.md) | Across a boot, is the single core doing work, waiting on hardware, or queued behind something else? |
+| [`issue_investigation/wlan0_udev_queue/`](issue_investigation/wlan0_udev_queue/README.md) | What occupies the gap between the WiFi chip appearing on the bus and `wlan0` existing, and what is removing it worth? |
+| [`issue_investigation/first_boot_after_ota/`](issue_investigation/first_boot_after_ota/README.md) | What does the first boot of a freshly written slot cost, and how long is the device unreachable? |
+| [`issue_investigation/wifi_instability/`](issue_investigation/wifi_instability/README.md) | Which WiFi failure hypotheses were tested and dropped, and how was the fault finally captured? |
+| [`issue_investigation/netcheck_nolan_recovery/`](issue_investigation/netcheck_nolan_recovery/README.md) | Has the no-LAN good-marking withhold been seen to fire, to stay quiet, and to suppress itself? |
+| [`issue_investigation/surf_memory_soak/`](issue_investigation/surf_memory_soak/README.md) | Does a fitted slope over the soak log tell you whether the browser is leaking? |
+| [`issue_investigation/screenshot_capture_fbgrab/`](issue_investigation/screenshot_capture_fbgrab/README.md) | Which framebuffer capture path produces a screenshot that can be trusted as a liveness check? |
+| [`issue_investigation/webkit_dependency_trims/`](issue_investigation/webkit_dependency_trims/README.md) | Can the accessibility stack be taken out of the image, from the build side or at runtime? |
+
+Each investigation is a directory whose `README.md` carries exactly four sections in this order —
+*Configuration under test*, *How the test was performed*, *Metrics*, *Changes configured as a
+result* — with any raw captures as siblings beside it; match that shape when adding the next one.

--- a/docs/issue_investigation/boot_cpu_saturation/README.md
+++ b/docs/issue_investigation/boot_cpu_saturation/README.md
@@ -1,0 +1,139 @@
+# Boot CPU saturation — is the core busy, waiting, or queued?
+
+A boot window can be long because the core is **doing work**, because it is **waiting**, or because
+something is **queued behind unrelated work**. The three have different fixes, and on a single core
+the first two have opposite ones: overlapping phases helps only when the core is idle during one of
+them. This is the baseline measurement that decides which case this board is in, and it is the
+evidence base the other boot investigations here are ranked against.
+
+## Configuration under test
+
+Image-default service configuration on the Pi Zero W, n=3 boots, 2026-08-12. Eleven service masks
+from an earlier campaign were reverted before the first boot, so the arm is the image as built: no
+module blacklist, no masks, no reordering.
+
+The instrument is the
+[`kiosk-bootprof`](../../../meta-wisekiosk/recipes-core/kiosk-bootprof/kiosk-bootprof_1.0.bb)
+sampler at 2 Hz, with
+[`analyze-boot-cpu-io.py`](../../../meta-wisekiosk/recipes-core/kiosk-bootprof/files/analyze-boot-cpu-io.py)
+reducing its samples to per-window figures and
+[`measure-surf.sh`](../../../meta-wisekiosk/recipes-core/kiosk-bootprof/files/measure-surf.sh)
+timing complete display. The sampler's cost, its blind spots and the SSH-session cost that
+contaminates a run are documented at
+[the tool](../../../meta-wisekiosk/recipes-core/kiosk-bootprof/README.md); every figure below is
+kernel-relative and excludes U-Boot, because `CLOCK_MONOTONIC` and `/proc/uptime` both start at
+kernel entry.
+
+## How the test was performed
+
+Window edges are taken from each boot's own journal read with `-o short-monotonic`. Wall-clock
+stamps are not comparable on this image — there is no RTC — so monotonic time is the only usable
+clock. `kiosk-bootprof` samples `/proc/stat`, `/sys/block/mmcblk0/stat` and `/proc/loadavg` into a
+preallocated buffer and writes once at the end, so measuring adds no SD writes to the window being
+measured.
+
+Four finish lines are quoted for this image and they are not interchangeable. Any figure compared
+against one of them must use the same row:
+
+| Endpoint | What it means |
+|---|---|
+| SSH reachable | the lifeline answers again |
+| `SURFMS uptime_at_exec` | `surf` is exec'd |
+| `SURFMS load_finished` | WebKit finished the page load |
+| complete display | weather icons rendered — the only endpoint a viewer sees |
+
+Two overlap-based routes were then tested against this baseline: starting Xorg in parallel with the
+network wait, evaluated against the idle-time ceiling below, and a `DefaultDependencies=no` drop-in
+on `wpa_supplicant.service` so it starts as soon as `wlan0` exists rather than waiting for
+`sysinit.target`/`basic.target`. The second was applied to the device and measured n=3.
+
+## Metrics
+
+Aggregate over the 60 s window from boot:
+
+| | boot 1 | boot 2 | boot 3 | mean |
+|---|---|---|---|---|
+| wall, boot → 60 s window | 52.0 s | 51.5 s | 52.0 s | 51.8 s |
+| **CPU busy** | 85.2 % | 84.2 % | 86.8 % | **85.4 %** |
+| **idle** | 10.18 % | 10.25 % | 8.44 % | **9.6 %** |
+| iowait | 4.60 % | 5.54 % | 4.75 % | 5.0 % |
+| total idle, seconds | 5.26 s | 5.25 s | 4.37 s | 4.96 s |
+| CPU work in the boot | 44.3 s | 43.4 s | 45.1 s | 44.3 s |
+| run queue, excluding the sampler | mean 5.52, max 19 | — | — | ~5.5 runnable |
+
+Milestones over the same three boots:
+
+| Milestone | mean |
+|---|---|
+| `wlan0` exists | 32.63 s |
+| network online | 36.30 s |
+| `surf` exec | 40.00 s |
+| `load_finished` | 49.80 s |
+
+Per window, same three boots:
+
+| Window | wall | busy % | idle % | iowait % | |
+|---|---|---|---|---|---|
+| local filesystems | 11.5 s | 99.67 | 0.00 | 0.38 | before the gate |
+| sysinit → basic | 5.2 s | 100.00 | 0.00 | 0.00 | before the gate |
+| **waiting for `wlan0`** | 8.8 s | **100.00** | **0.00** | **0.00** | **the gate** |
+| assoc + DHCP | 4.0 s | 84.77 | 13.97 | 1.25 | after |
+| Xorg → `surf` exec | 4.3 s | 76.43 | 5.60 | 17.96 | after |
+| `surf` → `load_finished` | 10.2 s | 81.10 | 3.94 | 14.93 | after |
+
+**The idle counter advances by exactly zero jiffies before `wlan0` appears** — across the
+local-filesystems, sysinit and `wlan0` windows, on every boot measured. All of the boot's idle and
+iowait lies after the gate.
+
+**The scheduling ceiling.** On one core, reordering reclaims only time the core was not executing,
+because overlapping two runnable tasks conserves total CPU time:
+
+```
+reclaimable by any scheduling change  =  idle + iowait  =  7.65 / 8.10 / 6.84 s   (mean 7.53 s)
+CPU work already in the boot          =  44.3 / 43.4 / 45.1 s   (mean 44.3 s)
+```
+
+The Xorg-parallel-with-network proposal was valued at 7–11 s. That range spans and exceeds the whole
+boot's scheduling budget, and none of the budget lies in the window it targets: `waiting for wlan0`
+measures 0.00 % idle and 0.00 % iowait on every boot. There is nothing there to overlap into.
+Starting Xorg earlier adds a competing process to a run queue already averaging ~5.5 runnable tasks
+on one core.
+
+The `wpa_supplicant` reorder tested that accounting directly, n=3:
+
+| | before | after | Δ |
+|---|---|---|---|
+| network online | 28.51 s | 22.97 s | −5.55 s |
+| `surf` exec | 31.54 s | 40.28 s | **+8.74 s** |
+
+Network online moved earlier exactly as intended; `surf` exec moved 8.74 s later, net 3.2 s worse,
+reproducible to the hundredth of a second across three boots (40.24 / 40.28 / 40.34 s).
+`kiosk.service` was released 6.8 s earlier into a machine still running dbus, journal flush, RAUC
+mark-good, RF-kill and the tail of udev, and took 15.5 s longer to start once released. Releasing
+work earlier without removing any of it converts a wait into a queue.
+
+Endpoint values on this configuration:
+
+| Endpoint | Value |
+|---|---|
+| SSH reachable | 53–56 s (n=8) |
+| `SURFMS uptime_at_exec` | 39.67 s (n=3) |
+| `SURFMS load_finished` | 51.10 / 48.79 / 50.48 → 50.12 s (n=3) |
+| complete display | 53.42 / 54.89 / 52.65 → 53.65 s (n=3) |
+
+**The window between `load_finished` and complete display is large and noisy** — 3.53 s on this
+baseline, 6.49 s on a module-blacklist boot. It is the page's own post-load fetching and rendering,
+which depends on the backend, so it is not a property of the boot. A complete-display delta smaller
+than ~2 s is not a boot result: the baseline's own spread is 2.24 s across three boots, and one
+blacklist boot never reached icon render at all within ~165 s despite `load_finished` at 46.80 s.
+
+## Changes configured as a result
+
+None. Both overlap-based routes are closed: the Xorg reorder is excluded by the ceiling above, and
+the `wpa_supplicant` drop-in was measured and reverted, leaving no code to carry it.
+
+The lever this baseline points at is removing CPU work ahead of `sysinit.target`/`basic.target`,
+which is pursued in [`wlan0_udev_queue`](../wlan0_udev_queue/README.md) and lands at
+[`kiosk-blacklist.conf`](../../../meta-wisekiosk/recipes-core/kiosk-hardware/files/kiosk-blacklist.conf).
+Timings taken on a slot's first boot after an OTA are not comparable with these — see
+[`first_boot_after_ota`](../first_boot_after_ota/README.md).

--- a/docs/issue_investigation/first_boot_after_ota/README.md
+++ b/docs/issue_investigation/first_boot_after_ota/README.md
@@ -1,0 +1,66 @@
+# The first boot of a freshly OTA'd slot
+
+Two things fire once, on the first boot of a slot that has just been written, and both distort
+anything measured on that boot: units gated on `ConditionNeedsUpdate=`, and OpenSSH host-key
+generation. This investigation establishes what they cost and how long the device is unreachable.
+
+## Configuration under test
+
+A RAUC slot immediately after a bundle install, against its own second boot. Two runs, on different
+slots and different images: slot A on 2026-08-13 (host keys, `surf` exec), and an OTA'd slot on
+2026-08-12 (`ConditionNeedsUpdate=` units, `brcmfmac`/`wlan0`). Both slots carry their own
+`machine-id`; `/data` is shared and unchanged across the pair.
+
+`ldconfig`, `systemd-journal-catalog-update` and `systemd-machine-id-commit` are the three units
+gated on `ConditionNeedsUpdate=`. They run on a boot that follows a freshly written slot and skip on
+every boot after it.
+
+## How the test was performed
+
+Boot 1 and boot 2 of the same slot were compared from the journal in `-o short-monotonic`, with no
+change between them other than the reboot. The `ConditionNeedsUpdate=` units were confirmed to skip
+on the second boot rather than inferred from the timing difference. Reachability during key
+generation was read from the keygen unit's own journal lines against `sshd.socket`'s listen time.
+
+## Metrics
+
+`ConditionNeedsUpdate=` cost, one OTA'd slot, first boot against second:
+
+| | boot 1 (first after OTA) | boot 2 (steady) | Δ |
+|---|---|---|---|
+| `brcmfmac` | 24.21 s | 23.28 s | −0.93 s |
+| `wlan0` | 28.54 s | 26.91 s | −1.63 s |
+
+Roughly 770 ms of CPU is removed by skipping those units, and `wlan0` moves 1.63 s — consistent with
+the CPU-saturation finding in [`boot_cpu_saturation`](../boot_cpu_saturation/README.md). **The
+mechanism is established; the 1.63 s magnitude is n=1 and is not.** `ldconfig` itself burns 369 ms of
+CPU spread across 3.64 s of wall clock: timesliced, not slow.
+
+Host-key generation on slot A's first boot:
+
+```
+25.13  Starting OpenSSH Key Generation...
+25.77    generating ssh RSA host key...     <- 25.6 s
+51.35    generating ssh ECDSA host key...
+51.69    generating ssh ED25519 host key...
+52.07  Finished OpenSSH Key Generation
+```
+
+`sshd.socket` listens at 23.98 s but cannot serve a session until the keys exist, so the device is
+**unreachable over SSH for roughly the first 50–80 s after an OTA**. `ping` answers throughout, and
+is the check to use in that window. A failed connection there is not a failed update.
+
+That 27 s of key generation runs on the same saturated core as the browser start, so it inflates the
+boot it happens on: `surf` exec read 33.05 s on slot A's first boot against 31.26 s on its second,
+with zero keygen lines — 1.79 s, measured on a different slot, image and `machine-id` from the
+`ConditionNeedsUpdate=` pair above.
+
+## Changes configured as a result
+
+None. The behaviour is upstream systemd and OpenSSH working as designed, and both effects are
+one-shot.
+
+The standing consequence is a measurement rule: **take the steady-state number from the second boot,
+never the first**, and do not read an unreachable device in the first ~80 s after an OTA as a failed
+update. Related but distinct: issue #10 machine-id journald orphan on first OTA is a defect on the
+same first-post-OTA boot, not an instance of these two one-shot units.

--- a/docs/issue_investigation/netcheck_nolan_recovery/README.md
+++ b/docs/issue_investigation/netcheck_nolan_recovery/README.md
@@ -1,0 +1,56 @@
+# `kiosk-netcheck` — proving the no-LAN withhold in all three directions
+
+[`kiosk-netcheck`](../../../meta-wisekiosk/recipes-core/kiosk-netcheck/kiosk-netcheck_1.0.bb)
+withholds RAUC good-marking when a boot completes normally but comes up with no usable LAN. A check
+that withholds is worth nothing unless it has been seen to fire, to stay quiet, and to suppress
+itself — this is the record of it doing all three.
+
+## Configuration under test
+
+Runtime install of the check on slot A, 2026-08-13, with slot B holding the previous image and
+marked `good`. Three cases:
+
+| Case | Expected behaviour |
+|---|---|
+| healthy LAN | pass |
+| no LAN, partner slot `good` | withhold |
+| no LAN, partner slot **not** `good` | mark good anyway |
+
+The no-LAN cases are produced by pointing `TARGET` in `/data/kiosk-netcheck.conf` at an unroutable
+address. That fails the *check* while the real network stays up, so the lifeline into the board is
+never the thing under test.
+
+## How the test was performed
+
+The script was exercised directly first, then across real reboots, reading `BOOT_A_LEFT` from the
+U-Boot environment and unit state from the journal on each boot.
+
+The third case ran against a **stubbed `rauc status --output-format=shell`**, not against a live bad
+slot. That substitutes RAUC's output while exercising the real script, the real parser and the real
+branch; it does not prove that RAUC reports a genuinely bad slot in the shape the parser expects.
+The second case covers that half — it parsed real `rauc status` output and correctly found slot B
+`good`. Together the two cover the path; neither covers it alone.
+
+## Metrics
+
+| Case | Observed |
+|---|---|
+| healthy LAN | exit 0 in 93 ms; gateway answered at 28.4 s of boot |
+| no LAN, partner slot `good` | exit 1; `boot-complete` **inactive**, `rauc-mark-good` refused with "Dependency failed", `BOOT_A_LEFT` **3 → 2** |
+| no LAN, partner slot not `good` | exit 0, "WITHHOLDING SUPPRESSED" |
+| restore, reboot | `BOOT_A_LEFT` back to **3**, all units active, zero failed |
+
+The kiosk stayed `active` with its full browser tree through the failing boot. The blast radius is
+exactly one unit, because `rauc-mark-good` is the only thing on this image that requires
+`boot-complete.target` and `kiosk.service` does not.
+
+**Cost: `rauc-mark-good` moved 25.9 s → 30.1 s**, because it waits for the LAN. That widens the
+window between boot and good-marking during which a watchdog fire consumes a boot attempt.
+
+## Changes configured as a result
+
+None — validated the implementation as built. The check, its ordering against `boot-complete.target`
+and its withhold-only design are documented at
+[`kiosk-netcheck_1.0.bb`](../../../meta-wisekiosk/recipes-core/kiosk-netcheck/kiosk-netcheck_1.0.bb)
+and in the
+[script itself](../../../meta-wisekiosk/recipes-core/kiosk-netcheck/files/kiosk-netcheck).

--- a/docs/issue_investigation/screenshot_capture_fbgrab/README.md
+++ b/docs/issue_investigation/screenshot_capture_fbgrab/README.md
@@ -1,0 +1,51 @@
+# Screen capture — `fbgrab` against `imagemagick import`
+
+The kiosk has one liveness check that no process-level sampler can replace: look at the pixels and
+compare what they say against live data. `fbgrab` reads as broken and is not: the defect is in the
+alpha channel of what it writes, not in the pixels. This records what each capture path produces
+and how to read it, so the misreading is not made twice.
+
+## Configuration under test
+
+Two capture paths against the running kiosk's framebuffer on the Pi Zero W:
+
+- `fbgrab`, reading `/dev/fb0` directly;
+- `import -window root` from imagemagick, against the X root window.
+
+The kiosk renders through the legacy `bcm2708_fb` framebuffer, black background with sparse light
+text.
+
+## How the test was performed
+
+Each tool captured a screen that was demonstrably rendering the kiosk correctly, and the resulting
+PNG was inspected channel by channel rather than by eye in a viewer. Content was then checked
+against live data taken in the same command — the rendered clock against `date` on the device, and
+the METAR observation ID against the current cycle — so that a stale render cannot pass as a healthy
+one.
+
+## Metrics
+
+`fbgrab` writes **RGBA with every alpha byte 0**. A naive viewer composites that onto white, which
+is why the capture read as a wholly white PNG against a screen that was rendering correctly. The
+pixel data was intact the whole time; only the alpha channel was wrong.
+
+`import -window root` writes correct opaque pixels with no post-processing. Verified capture,
+2026-08-12: 1824×984, 8-bit grayscale, opaque, `min=0 max=255 mean=4.4`.
+
+The healthy signature for this display is `rgb min=0 max=255 mean≈4` — a mean near zero is normal on
+a black background and is **not** evidence of a blank screen. **`min == max` is.**
+
+Content check on the same capture: the clock read `7:35:48 pm, Wednesday August 12 2026` against
+`date` returning `19:35:48` in the same command; METAR `<METAR_STATION> 122253Z`, the current cycle;
+wait times varied; font rendered as Roboto Condensed rather than the DejaVu fallback.
+
+## Changes configured as a result
+
+`imagemagick` stays in `IMAGE_INSTALL:append` in
+[`kiosk-zero-w.yaml`](../../../kiosk-zero-w.yaml) as the only working capture path on this image.
+`fbgrab` is not in the image and is not restored: nothing needs it once `import` writes correct
+pixels, and its absence is the record of the trade.
+
+The capture, the blank-screen signature and the content-against-`date` check are scripted at
+[`kiosk-screenshot.sh`](../../../tools/kiosk-screenshot.sh), so the reading rule cannot be applied
+from memory.

--- a/docs/issue_investigation/surf_memory_soak/README.md
+++ b/docs/issue_investigation/surf_memory_soak/README.md
@@ -1,0 +1,76 @@
+# Reading the soak log — why a fitted slope reported a leak that was not there
+
+A 22.8 h window of `surf`/WebKit RSS read as a steady climb of +127.8 kB/h and was not a leak. This
+records the three estimators that were compared, which of them the data supports, and what the valid
+comparison is.
+
+## Configuration under test
+
+The live kiosk's browser family RSS, sampled by
+[`kiosk-soak.sh`](../../../meta-wisekiosk/recipes-core/kiosk-soak/files/kiosk-soak.sh) every five
+minutes into `/data/kiosk-soak.log`. `rss_total` — the whole `surf` + WebKit process family, not
+just the launcher — is the series in question; the renderer is a separate process and holds most of
+the memory. Two windows: a 6.5 h window and the 22.8 h window of 2026-08-08.
+
+## How the test was performed
+
+Three estimators were computed over the same samples and compared against each other:
+
+- the **endpoint delta**, last sample minus first;
+- a **least-squares slope over all samples**;
+- the same slope **excluding hour 0**, on the argument that warm-up is not a leak.
+
+The window was then segmented by eye against the hourly means, and the page content at each segment
+boundary was compared by screenshot. Finally, `rss_total` was compared between two windows in the
+same page state 24 h apart.
+
+## Metrics
+
+Estimators over the 6.5 h window:
+
+| Estimator | Reading |
+|---|---|
+| endpoint delta | +192.6 kB/h — 4.6 MB/day, indistinguishable from a slow leak |
+| fitted slope, all samples | +21.4 kB/h |
+| fitted slope, excluding hour 0 | −15.8 kB/h |
+
+The first sample merely happened to be the lowest in the series.
+
+The 22.8 h window read +127.8 kB/h excluding hour 0, with near-monotonic hourly means. Segmented:
+
+| Segment | Slope |
+|---|---|
+| first eight hours | +24.9 kB/h |
+| two-hour step, 1.4 MB | +438.2 kB/h |
+| final six hours | +34.4 kB/h |
+
+One line through a step function reports the step as a rate. **A leak does not hold still for eight
+hours and then hold still again at a new level** — flat stretches either side of a step are what
+distinguish a working-set expansion from accumulation, and the fitted rate cannot.
+
+The step's cause was outside the browser: every wait-time row on the page went from `Closed` to a
+live value between 08:00 and 10:00, which is more DOM and more text. Identifying it explains the
+step's timing and settles nothing about recurrence — when the rows returned to `Closed`, `rss_total`
+stayed **1.66 MB above** the matched closed-state window 24 h earlier. The allocator keeps the pages
+rather than returning them.
+
+A healthy window on this image: hourly means inside a ~±150 kB band on a ~165 MB working set, with a
+slope whose sign is not stable between windows.
+
+## Changes configured as a result
+
+`kiosk-soak.sh --summary` prints the endpoint delta labelled `NOT a rate`, next to the fit, because
+seeing the two together is what makes the difference legible; it also notes that `load1` includes
+the sampler's own wake-up. Both are in
+[`kiosk-soak.sh`](../../../meta-wisekiosk/recipes-core/kiosk-soak/files/kiosk-soak.sh).
+
+Two guards this investigation calls for are not implemented: a two-point series must report `n/a`
+rather than a slope, and gaps in `ts` (consecutive differences should be ~301 s) must be detected
+rather than silently fitted across. Both are tracked by issue #27 kiosk-soak --summary: guard the
+two-point series and detect gaps in ts.
+
+The valid leak comparison is matched content states 24 h apart — closed-state against closed-state —
+never before-and-after a content change, which guarantees a difference and answers a question nobody
+asked. None of this detects a frozen page: every field would look identical if the display had been
+showing a stale render for hours, which is what
+[`screenshot_capture_fbgrab`](../screenshot_capture_fbgrab/README.md) covers.

--- a/docs/issue_investigation/webkit_dependency_trims/README.md
+++ b/docs/issue_investigation/webkit_dependency_trims/README.md
@@ -1,0 +1,65 @@
+# WebKit dependency trims — two closed routes
+
+`at-spi2-core` holds ~11.9 MB of RSS on a 437 MB board for accessibility nothing on this kiosk uses,
+which makes it the largest single RAM win available that is not the browser itself. There is no
+route to removing it, and the reason is the same dependency graph that makes touching `dbus` as
+expensive as touching `systemd`. This records both closed routes so neither is re-investigated.
+
+## Configuration under test
+
+The image as built: `webkitgtk3` with `systemd` in `DISTRO_FEATURES`, `at-spi2-registryd` (6.3 MB)
+and `at-spi-bus-launcher` (5.6 MB) resident in the kiosk session. Neither is started by a systemd
+unit, so neither appears in a per-unit CPU or memory table.
+
+Two removal routes were examined: a build-side removal of the `at-spi2-core` package, and a runtime
+neutralisation of the daemons from the kiosk launcher's environment.
+
+## How the test was performed
+
+The build side was traced through the recipes themselves — `DEPENDS`, `PROVIDES` and the
+`PACKAGECONFIG` third field — and the cost of a change was estimated with
+`bitbake -S printdiff` against a `DISTRO_FEATURES` edit.
+
+The runtime side was tested on the device: `NO_AT_BRIDGE=1` and `GTK_A11Y=none` were added to the
+launcher and the board rebooted. Whether the variables reached the process was confirmed by reading
+`/proc/<surf pid>/environ` rather than assumed from the edit, and the surviving processes were
+attributed by reading their `PPid`.
+
+## Metrics
+
+The chain from `systemd` to WebKit, and what a `bitbake -S printdiff` estimate of it is worth, are
+recorded at
+[`packagegroup-base.bbappend`](../../../meta-wisekiosk/recipes-core/packagegroups/packagegroup-base.bbappend),
+next to the edit whose cost it decides. Two hops that look like the path and are not: `at-spi2-core`'s
+own `inherit systemd` adds only `systemd-systemctl-native`, a native helper; and `gtk+3` reaches
+systemd through `atk` as well, so it is a parallel branch rather than the route. Every hop is a
+genuine upstream dependency; nothing this repository does creates it.
+
+**Route 1, build-side removal: closed.** `at-spi2-core` PROVIDES `atk`, which `webkitgtk3`
+build-depends on, so removing the package takes WebKit's build with it.
+
+**Route 2, runtime neutralisation: closed.** All three at-spi processes returned unchanged after the
+reboot. The environment variables were not ignored — they reached the process — but they suppress
+the in-process atk bridge, which is a different thing from the daemons. `at-spi-bus-launcher` runs
+with `PPid 1` because it is started by D-Bus activation through
+`/usr/share/dbus-1/services/org.a11y.Bus.service`, not by surf's GTK. Nothing set in the launcher's
+environment can prevent that.
+
+**Cost of touching `dbus`.** `bitbake -S printdiff` for a `DISTRO_FEATURES:remove` reports only
+`systemd:do_configure` and `packagegroup-base:do_package` as unusable, with zero WebKit tasks, and
+builds touching systemd have run ~11 minutes with no WebKit rebuild. That is the observation, not a
+licence: why it cannot be read as a guarantee is at the recipe comment linked above. A `dbus` change
+carries the same multi-hour WebKit-rebuild exposure as a `systemd` change.
+
+## Changes configured as a result
+
+None. Nothing in the layer touches `dbus`, and the launcher is the image copy — the runtime arm was
+reverted.
+
+One option remains untried and is declined: masking the D-Bus activation file for
+`org.a11y.Bus.service`. It risks GTK blocking on a failed activation, for ~12 MB on a board with
+320 MB available.
+
+The dependency chain as stated here is the one recorded at
+[`kiosk-hardware_1.0.bb`](../../../meta-wisekiosk/recipes-core/kiosk-hardware/kiosk-hardware_1.0.bb),
+which is why that recipe is a separate recipe rather than a systemd bbappend.

--- a/docs/issue_investigation/wifi_instability/README.md
+++ b/docs/issue_investigation/wifi_instability/README.md
@@ -1,0 +1,133 @@
+# WiFi instability — the routes that were ruled out, and how the fault was captured
+
+For two days the working hypothesis was that the SDIO bus, the brcmfmac driver, or the WiFi firmware
+was defective. All three variants are dead: the board corrupts memory at its top CPU OPP under
+sustained load, and the fix is the frequency cap shipped by
+[`kiosk-cpufreq`](../../../meta-wisekiosk/recipes-core/kiosk-cpufreq/kiosk-cpufreq_1.0.bb), which
+carries the dose-response evidence and the reason it ships as a unit rather than as `config.txt`.
+This page is the residue: the negative results, the instrumentation lessons, the fault analysis
+underneath that two-line summary, and the raw captures.
+
+## Configuration under test
+
+Pi Zero W, BCM43430A1 over SDIO with brcmfmac, kernel 6.6.63, under sustained network receive and
+transmit — the load an OTA bundle transfer produces. Arms across the campaign varied burst size,
+average rate, WiFi power save, firmware build, kernel patch set and CPU governor, one variable at a
+time, against a transfer large enough to kill the board reliably.
+
+Fault capture ran on the same board with `ramoops`/`pstore` reserved across the reset, and with
+`slub_debug=FZPU` armed on one arm.
+
+## How the test was performed
+
+**The wedge model.** Sustained receive and sustained transmit could each hang the board; dose-response
+across burst size and average rate produced apparent thresholds (~0.9 MB/s, later revised to a
+burst-size effect) that looked like a receiver limit. Under-voltage was ruled out — `get_throttled`
+stayed `0` through every death — and plain CPU starvation was ruled out, because the board still
+hung at 12 % idle over plain HTTP, which has no crypto to blame. Two firmware builds, swapped at
+runtime through `/sys/module/firmware_class/parameters/path`, crashed identically. Every one of
+these was a real measurement of a real device death, and every one was measuring the true cause at
+one remove: a higher receive rate drives more CPU demand, which drives `ondemand` to its top OPP.
+The evidence for the wedge model is recorded in issue #5 sustained SDIO traffic wedges the board.
+
+**The kernel-bump chase.** `slub_debug=FZPU` found no redzone or poison violation, ruling out a
+simple buffer overrun. A review of brcmfmac's upstream history found two real fixes missing from the
+pinned tree, but the scatterlist table-size bug was measured on the device to be nowhere near
+triggered at safe rates — mean glom depth 4.8 against a 35-entry table — and the null-guard fix has
+never been backported to any 6.6.y stable branch. Neither is the cause, so a kernel version bump
+would not have fixed this regardless of which fix it delivered. Both patches ship anyway; the
+reasoning is at
+[`linux-raspberrypi_%.bbappend`](../../../meta-wisekiosk/recipes-kernel/linux/linux-raspberrypi_%.bbappend).
+
+**The sender-starvation lesson.** `mmc1` interrupts falling to the idle rate during a stall looked
+like proof the firmware had stopped delivering frames. Sampling the *sender's* TCP state (`ss -ti`)
+during the same window showed `unacked: 0` and `lastsnd: 3552ms` — nothing was outstanding because
+the sender had nothing to send. The pacing loop was a fork-per-chunk `dd` plus `sleep 0.1`, running
+on a host at load average 28 under a WebKit build, and measured independently at 29 KB/s against a
+requested 640 KB/s. **A receiver-only instrument cannot see a sender-side stall.** Every later arm
+sampled the sender too, and counted a device stall only when the sender was demonstrably pushing —
+`unacked > 0` and `lastsnd` small while the device's byte counter stayed flat. An arm built to that
+rule did show a genuine device-side collapse: `cwnd` fell to 1 with seven backed-off retransmits,
+none acknowledged.
+
+**Panic recovery, proven by making it fire.** `echo c > /proc/sysrq-trigger`, twice, after
+`rauc-mark-good` had already run so the test could not consume a boot attempt.
+
+**ramoops feasibility.** The question was whether a persistent RAM store could capture a hard-lockup
+panic across a reboot, and which zone to rely on.
+
+## Metrics
+
+**OTA blocked at 64 MB of 130 MB.** The chunk-and-pause shape that had moved 133 MB with zero hangs
+stopped converging once the destination passed ~60 MB. Each attempt landed one chunk, the board
+hung, and the unsynced append was lost on reboot, so the file rolled back:
+
+| Run | chunks landed | transfer failures |
+|---|---|---|
+| 1 | 14 | 2 |
+| 2 | 0 | 1 |
+| 3 | 2 | 1 |
+| 4 | 0 | 3 |
+| 5 | 1 | 1 |
+
+Net progress across the last four runs was zero, and gentler pause variants (6 s, 8 s) hung the same
+way. Nothing was damaged — `BOOT_ORDER=B A`, both slots `good`, kiosk active, no FAT errors — and
+every hang self-recovered. The attempt was stopped deliberately rather than ground against the risk
+of unclean shutdowns corrupting the FAT partition that holds `uboot.env`. This episode predates the
+top-OPP finding; the delivery design it produced is documented at
+[`send-bundle-chunked.sh`](../../../tools/send-bundle-chunked.sh).
+
+**Panic recovery bound.** Recovery from `sysrq`-triggered panic to SSH answering was **60 s** — a
+10 s `panic=10` delay plus a normal boot — confirmed by a changed `boot_id`, with counters at `3/3`,
+both slots `good` and no ext4 errors afterwards. That does not fix the 4.0 s `mmc_rescan` panic; it
+bounds an indefinite hang needing a person to a 60-second unattended outage. The mechanism underneath
+that panic is unknown.
+
+**The fault.** The oops is an *instruction fetch* abort: the CPU jumps to `PC = 0xc1137c58` and tries
+to execute data. That address is **constant across four separate crashes, under two different CPU
+governors**, while `LR` — the call site — differs each time. A random corruption gives a random
+target, so a constant target reached from different call sites is a deterministic computed jump, not
+a scribbled heap. The address resolves to roughly 1.09 MB past the end of the kernel image, in the
+region the early allocator uses: not a symbol, not module space, not the vector page.
+
+The oops printed no backtrace, because the frame pointer was garbage. Resolving the raw stack
+against `/proc/kallsyms` puts the crash in generic softirq code rather than inside brcmfmac:
+`net_rx_action → __napi_poll → process_backlog → __netif_receive_skb_one_core → deliver_skb`'s
+indirect call to the registered protocol handler. **brcmfmac is the packet source, not the faulting
+code** — the `Workqueue: brcmf_sdio_dataworker` line names where the packet came from, not where the
+corruption is.
+
+Raw captures:
+
+- [`oops-brcmf-sdio-dataworker-2026-08-13.txt`](oops-brcmf-sdio-dataworker-2026-08-13.txt) — the
+  register and stack dump the analysis above is built on.
+- [`oops-2-slub-debug-armed-2026-08-13.txt`](oops-2-slub-debug-armed-2026-08-13.txt) — the
+  corroborating capture with `slub_debug=FZPU` armed, carrying the SLUB alloc/free backtraces for
+  the faulting skb and netdev.
+
+**ramoops zone choice.** The **dmesg zone** would be empty for this failure shape: it fills only on
+a panic or oops path, and a watchdog-driven hard lockup never reaches one. The **console zone** is
+the win — it writes the kernel log tail synchronously as each line is printed, with no dependence on
+panic, which is exactly the evidence journald loses because it never gets to flush. It needs no
+kernel rebuild, only an explicit `console-size=` and the overlay, since the stock overlay ships the
+console zone disabled. `pstore/ftrace` would also work with interrupts disabled but needs a kernel
+rebuild and carries per-function-call overhead on a 1 GHz single core, and was not pursued. On this
+SoC a plain `reboot` and a watchdog reset are the same hardware event, so a passing reboot test is a
+passing watchdog-reset test for whether the region survives.
+
+## Changes configured as a result
+
+- The frequency cap that fixes the crash:
+  [`kiosk-cpufreq`](../../../meta-wisekiosk/recipes-core/kiosk-cpufreq/kiosk-cpufreq_1.0.bb) and its
+  [unit](../../../meta-wisekiosk/recipes-core/kiosk-cpufreq/files/kiosk-cpufreq-cap.service).
+- The two brcmfmac SDIO scatter-gather patches, carried as hygiene rather than as the fix:
+  [`linux-raspberrypi_%.bbappend`](../../../meta-wisekiosk/recipes-kernel/linux/linux-raspberrypi_%.bbappend).
+- `panic=10` on the kernel command line, and the ramoops overlay with an explicit `console-size=`:
+  the `panic-reboot` and `kiosk` blocks of [`kiosk-zero-w.yaml`](../../../kiosk-zero-w.yaml).
+- Chunked delivery, superseded by the cap above and tracked for removal by issue #29 remove chunked
+  bundle delivery: [`send-bundle-chunked.sh`](../../../tools/send-bundle-chunked.sh).
+
+Two threads stay open elsewhere: issue #11 cpufreq cap not in force during the first ~20s of boot
+tracks the window before the cap unit runs, and the `mmc_rescan` panic mechanism is tracked as its
+own hazard by issue #18 kernel panic at 4.0s in mmc_rescan, rather than by issue #5 sustained SDIO
+traffic wedges the board, whose premise is retired.

--- a/docs/issue_investigation/wifi_instability/oops-2-slub-debug-armed-2026-08-13.txt
+++ b/docs/issue_investigation/wifi_instability/oops-2-slub-debug-armed-2026-08-13.txt
@@ -1,0 +1,79 @@
+<1>[   66.325829] Unable to handle kernel paging request at virtual address c1137c58 when execute
+<1>[   66.325860] [c1137c58] *pgd=0100041e(bad)
+<0>[   66.325908] Internal error: Oops: 8000000d [#1] ARM
+<4>[   66.325939] Modules linked in: brcmfmac_wcc brcmfmac raspberrypi_hwmon brcmutil fixed cfg80211 rfkill sch_fq_codel zram zsmalloc fuse nfnetlink ipv6
+<4>[   66.326049] CPU: 0 PID: 33 Comm: kworker/u3:0 Not tainted 6.6.63 #1
+<4>[   66.326081] Hardware name: BCM2835
+<4>[   66.326106] Workqueue: brcmf_wq/mmc1:0001:1 brcmf_sdio_dataworker [brcmfmac]
+<4>[   66.326652] PC is at 0xc1137c58
+<4>[   66.326681] LR is at 0xc547bce4
+<4>[   66.326704] pc : [<c1137c58>]    lr : [<c547bce4>]    psr: a0000013
+<4>[   66.326730] sp : dc815ee0  ip : c082e990  fp : 00000000
+<4>[   66.326749] r10: c0f746f0  r9 : 00000000  r8 : 00000040
+<4>[   66.326772] r7 : c0f746a8  r6 : c1021898  r5 : c26aa020  r4 : c1fa6800
+<4>[   66.326798] r3 : 00000000  r2 : 00000005  r1 : 00000000  r0 : c26aa020
+<4>[   66.326821] Flags: NzCv  IRQs on  FIQs on  Mode SVC_32  ISA ARM  Segment user
+<4>[   66.326850] Control: 00c5387d  Table: 0488c008  DAC: 00000055
+<1>[   66.326872] Register r0 information: slab skbuff_head_cache start c26aa000 data offset 32 pointer offset 0 size 184 allocated at __netdev_alloc_skb+0xd4/0x17c
+<6>[   66.326987]     __netdev_alloc_skb+0xd4/0x17c
+<6>[   66.327025]     brcmu_pkt_buf_get_skb+0x20/0x40 [brcmutil]
+<6>[   66.327116]     brcmf_sdio_dataworker+0xd9c/0x2b2c [brcmfmac]
+<6>[   66.327494]     process_one_work+0x164/0x358
+<6>[   66.327545]     worker_thread+0x2b0/0x4d8
+<6>[   66.327582]     kthread+0xcc/0xf0
+<6>[   66.327621]     ret_from_fork+0x14/0x38
+<4>[   66.327651]  Free path:
+<6>[   66.327672]     brcmf_sdio_dataworker+0x1ec8/0x2b2c [brcmfmac]
+<6>[   66.328034]     process_one_work+0x164/0x358
+<6>[   66.328077]     worker_thread+0x2b0/0x4d8
+<6>[   66.328111]     kthread+0xcc/0xf0
+<6>[   66.328147]     ret_from_fork+0x14/0x38
+<1>[   66.328177] Register r1 information: NULL pointer
+<1>[   66.328212] Register r2 information: non-paged memory
+<1>[   66.328239] Register r3 information: NULL pointer
+<1>[   66.328267] Register r4 information: slab kmalloc-cg-2k start c1fa6000 data offset 2048 pointer offset 0 size 2048 allocated at alloc_netdev_mqs+0x5c/0x34c
+<6>[   66.328356]     __kmalloc_node+0x50/0x124
+<6>[   66.328404]     alloc_netdev_mqs+0x5c/0x34c
+<6>[   66.328435]     brcmf_add_if+0xf8/0x218 [brcmfmac]
+<6>[   66.328805]     brcmf_attach+0xfc/0x52c [brcmfmac]
+<6>[   66.329158]     brcmf_sdio_firmware_callback+0x7cc/0x9dc [brcmfmac]
+<6>[   66.329513]     brcmf_fw_request_done+0x164/0x190 [brcmfmac]
+<6>[   66.329869]     request_firmware_work_func+0x58/0x9c
+<6>[   66.329912]     process_one_work+0x164/0x358
+<6>[   66.329955]     worker_thread+0x2b0/0x4d8
+<6>[   66.329990]     kthread+0xcc/0xf0
+<6>[   66.330027]     ret_from_fork+0x14/0x38
+<1>[   66.330056] Register r5 information: slab skbuff_head_cache start c26aa000 data offset 32 pointer offset 0 size 184 allocated at __netdev_alloc_skb+0xd4/0x17c
+<6>[   66.330153]     __netdev_alloc_skb+0xd4/0x17c
+<6>[   66.330192]     brcmu_pkt_buf_get_skb+0x20/0x40 [brcmutil]
+<6>[   66.330272]     brcmf_sdio_dataworker+0xd9c/0x2b2c [brcmfmac]
+<6>[   66.330643]     process_one_work+0x164/0x358
+<6>[   66.330689]     worker_thread+0x2b0/0x4d8
+<6>[   66.330727]     kthread+0xcc/0xf0
+<6>[   66.330763]     ret_from_fork+0x14/0x38
+<4>[   66.330794]  Free path:
+<6>[   66.330814]     brcmf_sdio_dataworker+0x1ec8/0x2b2c [brcmfmac]
+<6>[   66.331173]     process_one_work+0x164/0x358
+<6>[   66.331218]     worker_thread+0x2b0/0x4d8
+<6>[   66.331251]     kthread+0xcc/0xf0
+<6>[   66.331288]     ret_from_fork+0x14/0x38
+<1>[   66.331318] Register r6 information: non-slab/vmalloc memory
+<1>[   66.331353] Register r7 information: non-slab/vmalloc memory
+<1>[   66.331383] Register r8 information: non-paged memory
+<1>[   66.331412] Register r9 information: NULL pointer
+<1>[   66.331441] Register r10 information: non-slab/vmalloc memory
+<1>[   66.331470] Register r11 information: NULL pointer
+<1>[   66.331498] Register r12 information: non-slab/vmalloc memory
+<0>[   66.331528] Process kworker/u3:0 (pid: 33, stack limit = 0xdc9cc000)
+<0>[   66.331554] Stack: (0xdc815ee0 to 0xdc816000)
+<0>[   66.331587] 5ee0: c1021898 48bc7cef c26aa380 c1fa6800 00000000 c0f746f0 c0f746a8 48bc7cef
+<0>[   66.331620] 5f00: c1fa6800 c08fbc18 c0f746f0 c0855eac c09287c8 c26aa020 c0e1e910 48bc7cef
+<0>[   66.331652] 5f20: 00000000 00000000 00000000 c085601c 00000001 c0f746f0 dc815f73 00000040
+<0>[   66.331686] 5f40: c0e8ef20 dc815f80 c0f746f0 c08569f8 7130dc68 0000000f 00000006 c0f746a0
+<0>[   66.331716] 5f60: 0000012c dc815f78 ffffa4ba c0856e00 00ffffff 00000000 dc815f78 dc815f78
+<0>[   66.331745] 5f80: dc815f80 dc815f80 ffffffff 48bc7cef 00000007 00000003 00000004 c0f90760
+<0>[   66.331775] 5fa0: 00000008 c1d30000 00000101 00000000 0000000c c0027ecc ffffa4b9 00000009
+<0>[   66.331805] 5fc0: ffffa4b9 0000000a 00000000 04208060 00000000 c4a07000 60000013 60000013
+<0>[   66.331834] 5fe0: 000001ff 00000000 c4960580 c3ce3e10 bf1f52e8 0000000e dc9cddf0 c09f5984
+<0>[   66.331883] Code: 0001e230 e92d4070 e24dd0b8 e1a0600d (e59fe070) 
+<4>[   66.331914] ---[ end trace 0000000000000000 ]---

--- a/docs/issue_investigation/wifi_instability/oops-brcmf-sdio-dataworker-2026-08-13.txt
+++ b/docs/issue_investigation/wifi_instability/oops-brcmf-sdio-dataworker-2026-08-13.txt
@@ -1,0 +1,43 @@
+<1>[   63.752959] Unable to handle kernel paging request at virtual address c1137c58 when execute
+<1>[   63.752988] [c1137c58] *pgd=0100041e(bad)
+<0>[   63.753029] Internal error: Oops: 8000000d [#1] ARM
+<4>[   63.753056] Modules linked in: brcmfmac_wcc brcmfmac brcmutil raspberrypi_hwmon fixed cfg80211 rfkill sch_fq_codel zram zsmalloc fuse nfnetlink ipv6
+<4>[   63.753154] CPU: 0 PID: 33 Comm: kworker/u3:0 Not tainted 6.6.63 #1
+<4>[   63.753183] Hardware name: BCM2835
+<4>[   63.753204] Workqueue: brcmf_wq/mmc1:0001:1 brcmf_sdio_dataworker [brcmfmac]
+<4>[   63.753687] PC is at 0xc1137c58
+<4>[   63.753715] LR is at 0xc49eb964
+<4>[   63.753737] pc : [<c1137c58>]    lr : [<c49eb964>]    psr: a0000113
+<4>[   63.753759] sp : dc815ee0  ip : c082e990  fp : 00000000
+<4>[   63.753778] r10: c0f746f0  r9 : 00000000  r8 : 00000040
+<4>[   63.753797] r7 : c0f746a8  r6 : c1021898  r5 : c23ea3c0  r4 : c20b0800
+<4>[   63.753818] r3 : 00000000  r2 : 00000005  r1 : 00000000  r0 : c23ea3c0
+<4>[   63.753839] Flags: NzCv  IRQs on  FIQs on  Mode SVC_32  ISA ARM  Segment user
+<4>[   63.753864] Control: 00c5387d  Table: 02ea0008  DAC: 00000055
+<1>[   63.753883] Register r0 information: slab skbuff_head_cache start c23ea3c0 pointer offset 0 size 184
+<1>[   63.753939] Register r1 information: NULL pointer
+<1>[   63.753968] Register r2 information: non-paged memory
+<1>[   63.753992] Register r3 information: NULL pointer
+<1>[   63.754023] Register r4 information: slab kmalloc-cg-2k start c20b0800 pointer offset 0 size 2048
+<1>[   63.754078] Register r5 information: slab skbuff_head_cache start c23ea3c0 pointer offset 0 size 184
+<1>[   63.754134] Register r6 information: non-slab/vmalloc memory
+<1>[   63.754162] Register r7 information: non-slab/vmalloc memory
+<1>[   63.754191] Register r8 information: non-paged memory
+<1>[   63.754220] Register r9 information: NULL pointer
+<1>[   63.754247] Register r10 information: non-slab/vmalloc memory
+<1>[   63.754276] Register r11 information: NULL pointer
+<1>[   63.754305] Register r12 information: non-slab/vmalloc memory
+<0>[   63.754334] Process kworker/u3:0 (pid: 33, stack limit = 0x267cafc7)
+<0>[   63.754371] Stack: (0xdc815ee0 to 0xdc816000)
+<0>[   63.754406] 5ee0: c1021898 2648b1ba c23eacc0 c20b0800 00000000 c0f746f0 c0f746a8 2648b1ba
+<0>[   63.754440] 5f00: c20b0800 c08fbc18 c0f746f0 c0855eac c0e286b8 c23ea3c0 c0e1e910 2648b1ba
+<0>[   63.754469] 5f20: 00000000 00000000 00000000 c085601c 00000001 c0f746f0 dc815f73 00000040
+<0>[   63.754502] 5f40: c0e8ef20 dc815f80 c0f746f0 c08569f8 80000193 c0052f0c c0e286a0 c0f746a0
+<0>[   63.754532] 5f60: 0000012c dc815f78 ffffa3b9 c0856e00 0057b000 00000000 dc815f78 dc815f78
+<0>[   63.754563] 5f80: dc815f80 dc815f80 c0f6caac 2648b1ba ffffa3b8 00000003 00000004 c0f90760
+<0>[   63.754592] 5fa0: 00000008 c1d08000 00000101 00000000 0000000c c0027ecc ffffa3b8 0000000a
+<0>[   63.754622] 5fc0: ffffa3b8 0000000a 00000000 04208060 00000000 c498a000 20000010 60000113
+<0>[   63.754652] 5fe0: 000001ff 00000000 c2ea4580 c2f39e10 bf1f22e8 0000000e dc9cddf0 c09f5984
+<0>[   63.754699] Code: b62fce94 b62fce8c 00000000 b62fce6c (b62fce74) 
+<4>[   63.754731] ---[ end trace 0000000000000000 ]---
+<0>[   63.769811] Kernel panic - not syncing: Fatal exception in interrupt

--- a/docs/issue_investigation/wlan0_udev_queue/README.md
+++ b/docs/issue_investigation/wlan0_udev_queue/README.md
@@ -1,0 +1,144 @@
+# The `wlan0` gate — module load order in udev's queue
+
+The WiFi chip is on the SDIO bus at 4.0 s and `wlan0` does not exist until 32.63 s. Every unit
+downstream waits on it. This investigation asks what occupies those 28 seconds, and what removing it
+is worth. The baseline it is measured against is
+[`boot_cpu_saturation`](../boot_cpu_saturation/README.md).
+
+## Configuration under test
+
+Six arms on the Pi Zero W, n=3 boots each, 2026-08-12, all against the image-default baseline:
+
+| Arm | What it changes |
+|---|---|
+| baseline | image default |
+| 4-module blacklist | `bcm2835_isp`, `bcm2835_codec`, `bcm2835_v4l2`, `snd_bcm2835` |
+| 8-module blacklist | the four above plus `vc_sm_cma`, `raspberrypi_gpiomem`, `uio`, `uio_pdrv_genirq` |
+| Bluetooth removed | `bthelper@.service` + `bluetooth` + `hciuart` masked |
+| stacked | 4-module blacklist and Bluetooth removal together |
+| `brcmfmac` preloaded | `/etc/modules-load.d/` entry, no work removed |
+
+The last arm is the control: it moves `wlan0` without removing any CPU work.
+
+## How the test was performed
+
+`kiosk-bootprof` records the first time each module appears in `/proc/modules`, capped at 1 Hz
+because `/proc/modules` is a seq_file over every loaded module and costs more than the three
+counters it samples alongside. Module loads mostly do not log, so the journal alone cannot say what
+udev is doing between 14.5 s and 28 s; the first-seen timeline can.
+
+Each arm's endpoints come from the journal in `-o short-monotonic` and from `measure-surf.sh`. An
+arm is treated as a result only where the three-boot ranges do not overlap the baseline's.
+
+Because a module blacklist can break the display, every arm was validated against real pixels: a
+framebuffer sample is read and reported as `rgb_min`/`rgb_max`/`rgb_mean`/`distinct`. The probe was
+seeded in both directions before it was trusted — a uniform buffer reads `BLANK`, and a failed read
+reports `PROBE FAILED` rather than blank.
+
+## Metrics
+
+The journal across the gap on an image-default boot:
+
+```
+ 4.00 s  mmc1: new high speed SDIO card at address 0001     <- the WiFi chip is on the bus
+27.33 s  brcmfmac: F1 signature read @0x18000000            <- the driver first touches it
+28.26 s  Firmware: BCM43430/1 wl0: ... version 7.45.98
+32.53 s  Found device /sys/subsystem/net/devices/wlan0
+```
+
+The last six seconds of that gap, read from the same journal:
+
+```
+21.28  rpi-gpiomem            24.02  snd_bcm2835          (audio)
+21.58  vc_sm_cma              25.00  videodev             (V4L2)
+22.07  mc: media interface    25.41  bcm2835_mmal_vchiq
+22.36  vc_sm_cma probe        26.04  bcm2835_isp
+22.84->23.34  vc_sm init      26.32  bcm2835_v4l2
+                              26.57->27.34  /dev/video10..23,31   (14 nodes)
+27.33  brcmfmac starts
+```
+
+Module first-seen timeline, image-default boot:
+
+```
+17.08  cfg80211, rfkill, uio, uio_pdrv_genirq
+21.08  fixed
+22.57  mc, raspberrypi_gpiomem, snd
+24.07  snd_pcm, snd_timer, vc_sm_cma, videobuf2_common, ecc, ecdh_generic
+25.08  brcmutil, snd_bcm2835, videodev
+26.59  videobuf2_dma_contig, videobuf2_memops, videobuf2_v4l2, videobuf2_vmalloc
+28.07  bcm2835_isp, bcm2835_v4l2, v4l2_mem2mem, brcmfmac
+```
+
+`cfg80211`, the module `brcmfmac` depends on, loads at 17.1 s — eleven seconds before the driver
+that needs it. Nothing about the WiFi stack is slow.
+
+Four-module blacklist against baseline, n=3:
+
+| | baseline | blacklisted | Δ |
+|---|---|---|---|
+| **`wlan0` exists** | 32.6 / 32.7 / 32.6 → 32.63 s | 29.2 / 29.5 / 29.2 → 29.30 s | **−3.33 s**, ranges do not overlap |
+| network online | 36.30 s | 33.90 s | −2.40 s |
+| **`surf` exec** | 40.2 / 39.6 / 40.2 → 40.00 s | 38.0 / 37.6 / 38.0 → 37.87 s | **−2.13 s**, ranges do not overlap |
+| `load_finished` | 49.80 s | 48.10 s | −1.70 s, ranges overlap — directional only |
+| CPU work in boot | 44.27 s | 43.53 s | −0.73 s |
+
+Stacked with the Bluetooth removal, same baseline:
+
+| | baseline | + modules | + modules + Bluetooth |
+|---|---|---|---|
+| `wlan0` exists | 32.63 s | 29.30 s | 29.10 s |
+| network online | 36.30 s | 33.90 s | 33.50 s |
+| `surf` exec | 40.00 s | 37.87 s | 36.73 s |
+| **`load_finished`** | 48.6 / 49.4 / 51.4 → 49.80 s | 48.10 s | 45.8 / 46.0 / 47.9 → **46.57 s** |
+| CPU work in boot | 44.27 s | 43.53 s | 41.47 s |
+
+The two changes stack and the combined `load_finished` ranges do not overlap the baseline's
+(45.8–47.9 against 48.6–51.4): **−3.23 s to `load_finished`, −2.80 s of CPU work.** The split
+matches what the arms act on — the modules buy the gate, Bluetooth buys CPU after the gate.
+
+Second pass, eight modules against baseline, n=3:
+
+| | baseline | 8-module blacklist |
+|---|---|---|
+| `wlan0` | 32.3 / 32.4 / 32.2 → 32.30 s | 28.9 / 28.9 / 28.8 → 28.87 s |
+| `surf` exec | 39.37 s | 37.33 s |
+| `brcmfmac` loads | 28.07 s | 25.97 / 26.49 / 25.98 s |
+
+−3.43 s against −3.33 s for the original four, on a baseline that had already moved 0.33 s from an
+unrelated journald fix. The four extra modules are worth roughly 0.1 s. The camera and audio stack
+was the entire effect.
+
+**`wlan0`'s timestamp is a proxy for CPU work removed, not the cause of the win.** Preloading
+`brcmfmac` moved `wlan0` from 24.82 s to 14.19 s — −10.63 s — and moved `surf` exec by −0.06 s,
+well inside run-to-run spread. `wpa_supplicant.service` inherits the implicit
+`After=sysinit.target basic.target` and starts only once those are reached, 11.25 s after `wlan0`
+already existed on that boot:
+
+```
+14.10  Found device .../wlan0
+22.14  Reached target System Initialization
+23.07  Reached target Basic System
+25.35  Starting Bring up wlan0 ... wpa_supplicant
+28.51  Reached target Network is Online
+```
+
+Association plus DHCP is only ~3.2 s of that 14.4 s wait. Every arm above that moved `wlan0` earlier
+also removed CPU work, and it is the CPU removed that moved `surf` exec; the two track together
+because both follow total CPU work. Rank a trim by whether it removes CPU work ahead of
+`sysinit.target`/`basic.target`, not by whether it moves `wlan0`.
+
+Display validation after the blacklist: `kiosk` active, three `surf` processes, X running, no new
+failed units, framebuffer reading `rgb_min=0 rgb_max=255 rgb_mean=2.03 distinct=227` against the
+baseline's `mean=1.84 distinct=221`.
+
+## Changes configured as a result
+
+Both blacklist passes and the Bluetooth kernel-module pass ship in
+[`kiosk-blacklist.conf`](../../../meta-wisekiosk/recipes-core/kiosk-hardware/files/kiosk-blacklist.conf),
+which carries the module list and the reason each entry is safe to remove.
+
+Pursuing the remaining gap as a queue-ordering problem is a closed line: the reorder control above
+moved `wlan0` earlier without removing work and bought nothing, and the direct reorder of
+`wpa_supplicant` measured in [`boot_cpu_saturation`](../boot_cpu_saturation/README.md) made `surf`
+exec 8.74 s worse.

--- a/justfiles/deploy.just
+++ b/justfiles/deploy.just
@@ -40,3 +40,35 @@ flash device:
     fi
     sync
     echo "Done. Safe to eject {{device}}."
+
+# Provision a freshly flashed card: mount /data, write the site config, unmount
+#
+# /data is the FOURTH partition, not the rootfs, and nothing about the card says
+# so -- writing the config into partition 2 leaves a unit that boots with no
+# network and no way in but a USB keyboard. The suffix differs by device class:
+# /dev/sdX takes a bare 4, mmcblk and nvme interpose a `p`.
+#
+# Verification is not here on purpose. It lives inside tools/provision.sh, which
+# runs it whether it was reached through this recipe or called directly -- a
+# check a human has to remember is a check that looks identical when it fails.
+[group('deploy')]
+[script('bash')]
+[doc("Mount a fresh card's /data, provision it from secrets.yaml, unmount")]
+provision-fresh-card device mountpoint="/mnt/kiosk-data":
+    set -uo pipefail
+    case "{{device}}" in
+        *mmcblk*|*nvme*) PART="{{device}}p4" ;;
+        *)               PART="{{device}}4"  ;;
+    esac
+    if [ ! -b "$PART" ]; then
+        echo "Error: $PART is not a block device -- flash the card first, and check the device name"
+        exit 1
+    fi
+    sudo mkdir -p {{mountpoint}}
+    sudo mount "$PART" {{mountpoint}} || { echo "could not mount $PART"; exit 1; }
+    # umount on every exit path: an unmounted-but-still-mounted card gets pulled
+    # out with the config still in page cache.
+    trap 'sudo umount {{mountpoint}} || echo "WARNING: {{mountpoint}} is still mounted"' EXIT
+    # Root is needed to own the written files, but sudo resets HOME, so the
+    # secrets path is resolved as the invoking user and passed through.
+    sudo KIOSK_SECRETS="${KIOSK_SECRETS:-$HOME/.config/wisekiosk/secrets.yaml}" tools/provision.sh card {{mountpoint}}

--- a/justfiles/device.just
+++ b/justfiles/device.just
@@ -35,3 +35,73 @@ status host:
     echo ""
     echo "=== Uptime ==="
     ssh root@{{host}} "uptime" || true
+
+# === Diagnostics ===
+#
+# Thin wrappers over tools/kiosk-*.sh. The reasoning behind each check lives in
+# the script it wraps; .claude/skills/kiosk-debug/SKILL.md decides which one a
+# given symptom calls for.
+
+# Takes a CIDR rather than a host: this is the recipe for when the address is
+# what you are missing.
+[group('device')]
+[doc("Ping-sweep a /24 and report Raspberry Pi OUIs from the ARP cache")]
+find cidr:
+    tools/kiosk-find.sh {{cidr}}
+
+# Run from the host serving the page -- netstat only sees its own sockets, so
+# the address to pass is the KIOSK's, not this host's.
+[group('device')]
+[doc("Infer browser state from TCP connections to the served page")]
+tcp-state kiosk-addr port="8080":
+    tools/kiosk-tcp-state.sh {{kiosk-addr}} {{port}}
+
+[group('device')]
+[doc("Capture the screen and check it is neither blank nor stale")]
+screenshot host out="":
+    tools/kiosk-screenshot.sh root@{{host}} {{out}}
+
+# n is a SAMPLE COUNT, not hours: the sampler writes one line every 5 minutes,
+# so 12 is the last hour and 288 the last day. Omitting it reads the whole log.
+[group('device')]
+[doc("Read the soak log summary from the device")]
+soak-summary host n="24":
+    tools/kiosk-ssh.sh root@{{host}} 'kiosk-soak.sh --summary {{n}}'
+
+# Costs a reboot of the device and about three minutes. outdir defaults to
+# local/ because the profile comes with a full journal dump -- hostname,
+# addresses, SSID -- and local/ is this repository's gitignored home for exactly
+# that; just runs recipes with cwd at the repository root, which is public.
+[group('device')]
+[doc("Profile one boot end to end: arm, reboot, collect, analyze, disarm")]
+bootprofile host outdir="local":
+    tools/kiosk-bootprofile.sh root@{{host}} {{outdir}}
+
+# Pull-only, and deliberately so: /data is the one thing on this device that a
+# reflash does not reproduce, and a backup recipe that can also write is a
+# restore path nobody has rehearsed. Restoring is `just provision-device` plus
+# whatever this archive holds, applied by hand.
+#
+# One plain stream, no chunking. Verifying that shape against the capped board
+# is part of #29 remove chunked bundle delivery; until then gzip -t below is
+# what says whether the transfer arrived whole.
+#
+# The tarball lands in local/: it holds /data/config/wpa_supplicant.conf and the
+# persistent journal, and local/ is this repository's gitignored home for
+# exactly that. just runs recipes with cwd at the repository root, which is
+# public.
+[group('device')]
+[script('bash')]
+[doc("Pull a dated tarball of the device's /data to this host")]
+kiosk-backup host="192.168.1.6":
+    SSH="ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
+    mkdir -p local
+    OUT="local/kiosk-data-$(date +%F).tar.gz"
+    if [ -e "$OUT" ]; then
+        echo "$OUT exists -- move it aside rather than overwriting today's backup"
+        exit 1
+    fi
+    $SSH root@{{host}} 'tar -czf - -C / data' > "$OUT"
+    # A truncated stream still leaves a file, and gzip is where that shows up.
+    gzip -t "$OUT" || { echo "$OUT does not decompress -- the transfer was cut short"; rm -f "$OUT"; exit 1; }
+    echo "wrote $OUT ($(du -h "$OUT" | cut -f1))"

--- a/justfiles/ota.just
+++ b/justfiles/ota.just
@@ -124,10 +124,10 @@ casync-stats store:
 
 # === Tier 1 delivery: plain .raucb, chunked ===
 #
-# This board wedges on sustained SDIO traffic in EITHER direction, and a plain
-# scp of the 133MB bundle hangs it in ~11s having moved 0 bytes. These recipes
-# encode the delivery shape that works; see the kiosk-reference project,
-# docs/experiment-log.md, for the measurements behind it.
+# The chunking these recipes encode is SUPERSEDED and retained only until #29
+# remove chunked bundle delivery lands. Root cause and measurements are in
+# meta-wisekiosk/recipes-core/kiosk-cpufreq and
+# docs/issue_investigation/wifi_instability/README.md.
 
 # NOT covered by `just build`, which makes core-image-base only -- shipping a
 # stale .raucb silently reinstalls the previous image.
@@ -187,21 +187,13 @@ kiosk-preflight image="build/tmp-raspberrypi0-wifi/deploy/images/raspberrypi0-wi
     fi
     echo "preflight OK"
 
-# Separates the receive burst from the sync: combining them is what hangs it.
-#
-# Defaults retuned 2026-08-13 from 2/4/3 to 8/2/2. The old values were simply
-# the first shape that worked and were never tested against anything; they put
-# ~7.3min of pure sleeping into a 20min transfer. Measured after seeding the
-# defect first (24MB continuous HUNG, 0 bytes, watchdog recovered):
-#
-#   24MB  chunk=8 rx=2 sync=2   32s   clean
-#   40MB  chunk=8 rx=2 sync=2   52s   clean
-#   125MB chunk=8 rx=2 sync=2   6min  15 bursts, 0 hangs, md5 MATCH
-#
-# 806KB/s against 104KB/s. The board needs DISCONTINUITY, not small chunks or
-# long pauses -- consistent with the trigger being continuous receive rather
-# than rate or volume. The mechanism is still not understood: this is a bound
-# established at operational scale, not an explanation.
+# SUPERSEDED. The wedge this chunking works around was a symptom, and the fix is
+# the clock cap in meta-wisekiosk/recipes-core/kiosk-cpufreq, already on main.
+# The mechanism is written up once, in that recipe's comments and in
+# docs/issue_investigation/wifi_instability/README.md -- do not restate it here.
+# Chunking stays in the tree only until its removal lands: #29 remove chunked
+# bundle delivery. Every default below was tuned against the uncapped board and
+# is kept unchanged so the removal has something to compare against.
 [group('ota')]
 [script('bash')]
 [doc("Deliver a bundle in chunked bursts, verified end to end")]
@@ -260,9 +252,18 @@ kiosk-reboot host="root@192.168.1.6":
 kiosk-ota host="root@192.168.1.6" kconfig="kiosk-zero-w.yaml": (kiosk-bundle kconfig) (kiosk-preflight "build/tmp-raspberrypi0-wifi/deploy/images/raspberrypi0-wifi/core-image-base-raspberrypi0-wifi.rootfs.ext4" "build/tmp-raspberrypi0-wifi/deploy/images/raspberrypi0-wifi/update-bundle-raspberrypi0-wifi.raucb" host) (kiosk-send "build/tmp-raspberrypi0-wifi/deploy/images/raspberrypi0-wifi/update-bundle-raspberrypi0-wifi.raucb" host) (kiosk-install host)
     @echo "Delivered and installed. Verify, then: just kiosk-reboot {{host}}"
 
-# Roll back to the other slot.
+# The [doc] attribute rather than a trailing comment: just takes the LAST
+# comment line before a recipe as its --list text, so a comment that grows
+# silently renames the recipe.
+#
+# What this fixes is a bad ROOTFS. Both slots mount the same /data, so a wrong
+# site config, a missing machine-id or a corrupt file there is identical on
+# either side of a rollback -- the boot counter simply drains to zero. If the
+# fault followed the update, roll back; if it followed a provisioning step,
+# re-provision.
 [group('ota')]
 [script('bash')]
+[doc("Roll back to the other slot")]
 kiosk-rollback host="root@192.168.1.6":
     SSH="ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
     $SSH {{host}} 'rauc status mark-bad booted; fw_printenv BOOT_ORDER BOOT_A_LEFT BOOT_B_LEFT'

--- a/kiosk-zero-w.yaml
+++ b/kiosk-zero-w.yaml
@@ -114,6 +114,9 @@ local_conf_header:
     RPI_KERNEL_DEVICETREE_OVERLAYS:append = " overlays/ramoops.dtbo"
     RPI_EXTRA_CONFIG:append = "\ndtoverlay=ramoops,total-size=0x40000,record-size=0x8000,console-size=0x20000\n"
     PACKAGECONFIG:append:pn-webkitgtk3 = " reduce-size"
+    # imagemagick is here for `import -window root`, the only screenshot path
+    # this image has: fbgrab was dropped on a misdiagnosis and never restored.
+    # See docs/issue_investigation/screenshot_capture_fbgrab/README.md.
     IMAGE_INSTALL:append = " surf kiosk-session kiosk-soak kiosk-journal kiosk-hardware kiosk-netcheck kiosk-bootprof zram wpa-supplicant-service packagegroup-core-x11 xwininfo xprop ttf-roboto imagemagick tzdata-core tzdata-americas"
 
     # serial-getty is a login prompt on a port with nothing attached, started at

--- a/meta-wisekiosk/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-wisekiosk/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -14,11 +14,10 @@
 # -- so a fresh card takes the COMPILED-IN default and saves that out. On a card
 # that already has a saved env, the saved value wins and this changes nothing.
 #
-# Deliberately not done with fw_setenv, per docs/image-migration.md: the env
-# shares its 0x4000 block with BOOT_ORDER and the RAUC slot counters, and a
-# write interrupted at the wrong moment drops U-Boot to a built-in default with
-# no RAUC boot logic -- an unbootable card. Baking it costs nothing and cannot
-# be interrupted.
+# Deliberately not done with fw_setenv: the env shares its 0x4000 block with
+# BOOT_ORDER and the RAUC slot counters, and a write interrupted at the wrong
+# moment drops U-Boot to a built-in default with no RAUC boot logic -- an
+# unbootable card. Baking it costs nothing and cannot be interrupted.
 #
 # Injected into the defconfig rather than shipped as a .patch so it survives
 # upstream edits to that file; delete-then-append keeps it idempotent across

--- a/meta-wisekiosk/recipes-core/kiosk-bootprof/README.md
+++ b/meta-wisekiosk/recipes-core/kiosk-bootprof/README.md
@@ -1,0 +1,50 @@
+# Using the boot profiler
+
+`kiosk-bootprof` samples `/proc/stat`, `/sys/block/mmcblk0/stat`, `/proc/loadavg` and
+`/proc/modules` from early boot and writes `/data/boot-cpu-io.<boot_id>.txt` once at the end;
+`analyze-boot-cpu-io.py` turns that into per-window CPU and I/O figures. Why the sampler is written
+the way it is belongs in `files/kiosk-bootprof.c`'s header, and what ships in the image belongs in
+`kiosk-bootprof_1.0.bb`. This file is about *taking* a profile and *reading* one — the parts the
+code cannot state about itself.
+
+## Capturing a boot
+
+`just bootprofile <host>` (`justfiles/device.just`) runs the whole cycle: enable the unit, reboot,
+wait out the observer window below, pull the samples and the matching journal, run the analyzer,
+disable the unit again.
+
+Do **not** `rm` the unit to stop it. It is image content, so a delete is undone by the next OTA and
+in the meantime the device disagrees with its own image. `systemctl disable kiosk-bootprofile` is
+the off switch.
+
+## Your own SSH session is an instrument, and it costs ~3.34s
+
+An `sshd` per-connection daemon burns **3 340 ms of CPU**, measured from its own `CPUUsageNSec` on
+the device. A connection opened at 32.2s during a profiling run landed inside browser startup and
+inflated `surf` exec on that boot. **One connection per boot, opened no earlier than 90s after the
+reboot** — not a session left attached across the window.
+
+Which figures a contaminated run still supports is worth stating exactly, because it decides what
+can be salvaged: this board has no network at all before ~30s, so nothing done from a workstation
+can reach `mmc1`, `brcmfmac`, `wlan0` or `Reached target Network is Online`. Those survive on any
+boot. Everything from `SURFMS uptime_at_exec` onward does not.
+
+90s clears the latest `surf` exec ever observed here (40.24s, on a deliberately misconfigured arm)
+with ~35s of margin. Raise it to 120s when complete display is the endpoint. The wait is latency,
+not a measurement parameter: it changes when the journal is read, never what the journal says, so
+shortening it does not invalidate comparison against arms measured earlier.
+
+## Limits of the data
+
+- **It does not cover the first ~8.6s.** systemd cannot run a unit before it starts, so the kernel
+  and early-systemd window is outside the samples entirely.
+- **It counts itself.** The sampler is a runnable process, so `nr_running` includes it — every run
+  queue figure from this tool is `nr_running - 1`.
+- **`io_ticks` is not populated by this kernel's mmc driver** — 0 at 3 minutes of uptime, 4050 at
+  4.8h. It is recorded but unusable over boot-length windows; `iowait %` and `rd_ms`/`wr_ms` are the
+  I/O figures to read.
+- **No PSI, no `systemd-analyze`.** `/proc/pressure/` does not exist (`CONFIG_PSI` is off) and
+  `systemd-analyze` is not on the image, so neither pressure stalls nor `blame`/`critical-chain` is
+  available as a cross-check.
+- **An instrumented boot runs ~1s longer in wall-clock than an uninstrumented one.** Compare
+  profiled boots against profiled boots.

--- a/meta-wisekiosk/recipes-core/kiosk-bootprof/files/kiosk-bootprof.c
+++ b/meta-wisekiosk/recipes-core/kiosk-bootprof/files/kiosk-bootprof.c
@@ -4,7 +4,8 @@
  * the boot's total CPU work, on a core that is 0% idle through startup. An
  * instrument that large changes the thing it measures: rewriting the shell
  * sampler from /proc/diskstats to /sys/block/<dev>/stat moved the headline
- * "scheduling headroom" figure by 45%. See docs/boot-profile-yocto.md.
+ * "scheduling headroom" figure by 45%.
+ * See docs/issue_investigation/boot_cpu_saturation/README.md.
  *
  * The cost here is three lseek+read pairs per sample against already-open fds,
  * into a preallocated buffer, with one write at the end. No forks, no execs,

--- a/meta-wisekiosk/recipes-core/kiosk-hardware/files/kiosk-blacklist.conf
+++ b/meta-wisekiosk/recipes-core/kiosk-hardware/files/kiosk-blacklist.conf
@@ -34,6 +34,11 @@ blacklist snd_bcm2835
 #   raspberrypi_gpiomem provides /dev/gpiomem; nothing on this kiosk uses GPIO
 #   uio, uio_pdrv_genirq userspace-IO plumbing with no consumer here
 #
+# Worth roughly 0.1s, which is nothing: kept for the resident module memory, not
+# for boot time. The measurement is in
+# docs/issue_investigation/wlan0_udev_queue/README.md -- do not re-run the
+# experiment expecting a different answer.
+#
 # NOT included: drm / backlight / drm_panel_orientation_quirks. They load at
 # 9.6s via modprobe@drm.service, well before the gate, and logind's seat setup
 # may want DRM -- breaking X to save nothing is a bad trade.

--- a/meta-wisekiosk/recipes-core/kiosk-hardware/kiosk-hardware_1.0.bb
+++ b/meta-wisekiosk/recipes-core/kiosk-hardware/kiosk-hardware_1.0.bb
@@ -1,8 +1,10 @@
 SUMMARY = "Kiosk hardware trim: keep unused subsystems out of the boot, and reboot on panic"
 DESCRIPTION = "Drop-in configuration only -- no binaries, no services. Deliberately a \
-separate recipe rather than a systemd_%.bbappend: touching the systemd recipe re-hashes \
-systemd -> gtk+3/at-spi2-core -> webkitgtk3, which is a multi-hour WebKit rebuild for three \
-config files. The same reasoning is why kiosk-journal exists."
+separate recipe rather than a systemd_%.bbappend: touching the systemd recipe risks a \
+multi-hour WebKit rebuild for three config files, and dbus is the load-bearing hop, not \
+gtk+3. The chain is at recipes-core/packagegroups/packagegroup-base.bbappend and the \
+removal routes it closes are in docs/issue_investigation/webkit_dependency_trims/README.md. \
+The same reasoning is why kiosk-journal exists."
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 

--- a/meta-wisekiosk/recipes-core/kiosk-session/files/kiosk-launch
+++ b/meta-wisekiosk/recipes-core/kiosk-session/files/kiosk-launch
@@ -24,6 +24,12 @@ if [ "${KIOSK_INSPECTOR:-0}" = "1" ]; then
 	INSPECT="-N"
 fi
 
+# There is no backend-readiness wait before the exec, and one must not be built
+# on busybox `nc`: it exits 1 against an open port as well as a closed one, so
+# the probe can never report success -- a readiness check that cannot pass looks
+# exactly like a backend that is never ready. kiosk.service already gates on
+# network-online.target, which is the part that was doing any work.
+#
 # Milestones go to BOTH the journal and a file: measure-surf.sh reads the file,
 # and the journal is what makes a first boot debuggable over SSH.
 exec surf -K $INSPECT "$KIOSK_URL" 2>&1 | tee /var/log/surf-milestones.log

--- a/meta-wisekiosk/recipes-core/kiosk-soak/files/kiosk-soak.sh
+++ b/meta-wisekiosk/recipes-core/kiosk-soak/files/kiosk-soak.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Kiosk soak sampler, ported from tools/kiosk-soak.sh for the Yocto image.
+# Kiosk soak sampler, ported from the Raspbian-era kiosk's sampler for the
+# Yocto image.
 #
 #   kiosk-soak.sh              take one sample
 #   kiosk-soak.sh --summary [N]   report over the last N samples (default: all)
@@ -14,6 +15,29 @@
 #     resolved with command -v rather than by grepping for a path. The principle
 #     is unchanged: ask the launcher, never hardcode. A sampler that names one
 #     browser records zeros for the other and calls it data.
+#
+# The fields that are not self-evident from the printf below:
+#   boot       first 8 of boot_id. A change means the device rebooted, and the
+#              samples either side are not one series
+#   pid        main browser pid. A change means the browser restarted; `none`
+#              means it was not running at that sample
+#   nproc      processes in the browser family (surf plus its WebKit children)
+#   rss_total  RSS across that whole family, and the memory number that matters
+#              -- the renderer is a separate process and holds most of it
+#   thr        vcgencmd get_throttled. Anything but 0x0 means it throttled at
+#              some point SINCE BOOT, not that it is throttling now
+#   ent        entropy pool. Low is expected; rngd is deliberately off for surf
+#
+# Read a --summary in this order, weakest evidence last:
+#   1. reboots and browser restarts. Non-zero means the memory series is really
+#      two series, and no rate fitted across it means anything
+#   2. samples w/o browser. Non-zero means the kiosk was down at those samples
+#   3. the shape of rss_total across the window, before any slope. This port
+#      prints no hourly mean, so that read is manual against the log
+#   4. the slope, last
+#
+# Why the order is that way, and why the endpoint delta is labelled NOT a rate:
+# docs/issue_investigation/surf_memory_soak/README.md.
 set -u
 LOG=${KIOSK_SOAK_LOG:-/data/kiosk-soak.log}
 LAUNCHER=${KIOSK_LAUNCHER:-/usr/bin/kiosk-launch}

--- a/meta-wisekiosk/recipes-graphics/packagegroups/packagegroup-core-x11.bbappend
+++ b/meta-wisekiosk/recipes-graphics/packagegroups/packagegroup-core-x11.bbappend
@@ -5,3 +5,11 @@
 # Bytes only. It is not a service and does not run at boot, so nothing here
 # should move the clock.
 RDEPENDS:${PN}-utils:remove = "xinput-calibrator"
+
+# rxvt-unicode IS in the image (manifest: rxvt-unicode 9.31-r0) and it arrives
+# through this packagegroup, but not from any RDEPENDS in this file: the chain is
+# packagegroup-core-x11 -> ${PN}-utils -> xserver-nodm-init -> xinit, and xinit's
+# own RDEPENDS names it. It installs as /usr/bin/rxvt{,c,d} through update-
+# alternatives, which is why a grep for "urxvt" comes back empty on a running
+# image that carries it. A removal has to target xinit's RDEPENDS; a remove line
+# here matches nothing.

--- a/tools/ci-guards.sh
+++ b/tools/ci-guards.sh
@@ -90,10 +90,12 @@ fi
 # and does not pretend to be; it needs nothing installed and never false-alarms.
 # The extensionless scripts are named explicitly because '*.sh' cannot see
 # them; the existence check keeps a rename from silently shrinking the scan,
-# same as guard 1b.
+# same as guard 1b. The pre-commit hook is in that set: it is the thing that
+# runs this script, so a syntax error in it disarms every guard here.
 scan3="meta-wisekiosk/recipes-core/kiosk-netcheck/files/kiosk-netcheck \
        meta-wisekiosk/recipes-core/kiosk-provision/files/kiosk-provision \
-       meta-wisekiosk/recipes-core/kiosk-session/files/kiosk-launch"
+       meta-wisekiosk/recipes-core/kiosk-session/files/kiosk-launch \
+       .githooks/pre-commit"
 missing3=""
 for p in $scan3; do [ -e "$p" ] || missing3="$missing3 $p"; done
 [ -n "$missing3" ] && bad "guard 3 cannot scan -- path renamed or removed:$missing3"

--- a/tools/doc-image.py
+++ b/tools/doc-image.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Check what the docs tell you to run against what the image actually ships.
+
+    doc-image.py check                      -- every git-tracked *.md vs the build tree
+    doc-image.py snapshot <rootfs> <out>    -- write a snapshot by hand, to inspect
+
+`doc-links.py` proves cross-references resolve; that checks the docs against
+themselves. This checks them against the image, which is the failure nothing
+else here catches.
+
+The failure it exists for, concretely: a doc prescribed running `fbgrab` on a
+device whose image no longer carried it, and nothing compared the two. The case
+is at docs/issue_investigation/screenshot_capture_fbgrab/README.md.
+
+Two claim kinds are checked, chosen because both are unambiguous in plain GFM
+and need no annotation, frontmatter or generator dialect in the source files:
+
+  1. Commands inside `ssh root@... '...'` invocations, and the same shape
+     through the kiosk-ssh.sh wrapper. The image logs in as root, so that
+     prefix scopes the check to the running device for free.
+  2. Backticked absolute paths under /usr/bin, /usr/sbin, /bin and /sbin.
+
+Deliberately NOT checked: bare commands in fenced blocks (ambiguous -- many run
+on the workstation), and paths under /data and /var (created at runtime, absent
+from the image by design). Adding those needs a scope marker the source files do
+not carry, and guessing produces noise that gets the whole check ignored.
+
+There is no waiver list. A path the image does not carry is either wrong in the
+doc or missing from the image, and both are worth fixing; an allowlist only
+records that neither was done.
+
+The snapshot is regenerated from the build tree on every run and written under
+build/, which is gitignored. A committed snapshot drifts from the image it
+claims to describe and nothing notices. With no build tree the check cannot run
+at all, and says so loudly rather than passing by default.
+"""
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+BIN_DIRS = ("usr/bin", "usr/sbin", "bin", "sbin")
+# Kept small on purpose: enough to answer questions the docs actually ask,
+# small enough that the snapshot stays reviewable in a diff. /usr/lib/modules
+# is excluded -- 1750 .ko files would bury every real change.
+PATH_DIRS = ("etc", "usr/lib/systemd/system", "usr/lib/udev/rules.d", "boot")
+
+BIN_PREFIXES = ("/usr/bin/", "/usr/sbin/", "/bin/", "/sbin/")
+
+# Where the regenerated snapshot lands. Under build/, which .gitignore covers,
+# so it cannot be committed and cannot drift.
+SNAPSHOT_SCRATCH = Path("build/.doc-image-snapshot.json")
+
+# The rootfs bitbake leaves behind for the image this repository builds. Newest
+# mtime wins: a machine that has built more than one target has more than one.
+ROOTFS_GLOB = "build/tmp-*/work/*/core-image-base/*/rootfs"
+
+# Shell builtins and control words that appear inside ssh '...' but are not
+# binaries the image has to carry.
+NOT_BINARIES = {
+    "if", "then", "else", "elif", "fi", "for", "do", "done", "while", "case",
+    "esac", "function", "return", "exit", "set", "unset", "export", "local",
+    "read", "eval", "exec", "source", "shift", "trap", "wait", "echo", "cd",
+    "test", "true", "false", "printf", "break", "continue", "time", "sudo",
+}
+
+
+def repo_top() -> Path:
+    return Path(subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                               capture_output=True, text=True,
+                               check=True).stdout.strip())
+
+
+def tracked_markdown(top: Path):
+    listing = subprocess.run(["git", "ls-files", "--", "*.md"], cwd=top,
+                             capture_output=True, text=True,
+                             check=True).stdout
+    return sorted(top / line for line in listing.splitlines() if line)
+
+
+def build_time(rootfs: Path) -> float:
+    """When the rootfs was actually built.
+
+    Not its own mtime: reproducible builds clamp every timestamp inside the
+    rootfs to SOURCE_DATE_EPOCH, so the directory reads as 2018 on a build from
+    this morning. The recipe workdir above it is not clamped. Take the later of
+    the two, so this stays right if a future build stops clamping."""
+    return max(rootfs.stat().st_mtime, rootfs.parent.stat().st_mtime)
+
+
+def find_rootfs(top: Path):
+    """The most recently built rootfs under build/, or None if there is none."""
+    candidates = sorted(top.glob(ROOTFS_GLOB), key=build_time, reverse=True)
+    return candidates[0] if candidates else None
+
+
+def scan_rootfs(rootfs: Path):
+    """(binaries, paths) as the image carries them, or (None, None) if the
+    directory holds no binaries -- an empty scan must not read as a pass."""
+    binaries, paths = set(), set()
+    for d in BIN_DIRS:
+        p = rootfs / d
+        if p.is_dir():
+            binaries.update(f.name for f in p.iterdir())
+    for d in PATH_DIRS:
+        p = rootfs / d
+        if p.is_dir():
+            for f in p.rglob("*"):
+                paths.add("/" + str(f.relative_to(rootfs)))
+    if not binaries:
+        return None, None
+    return binaries, paths
+
+
+def snapshot(rootfs: Path, out: Path) -> int:
+    if not rootfs.is_dir():
+        print(f"not a directory: {rootfs}", file=sys.stderr)
+        return 2
+    binaries, paths = scan_rootfs(rootfs)
+    if binaries is None:
+        print(f"no binaries found under {rootfs} -- wrong directory?", file=sys.stderr)
+        return 2
+    try:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps({
+            "rootfs": str(rootfs),
+            "binaries": sorted(binaries),
+            "paths": sorted(paths),
+        }, indent=1) + "\n")
+    except OSError as e:
+        print(f"cannot write {out}: {e}", file=sys.stderr)
+        return 2
+    print(f"{out}: {len(binaries)} binaries, {len(paths)} paths")
+    return 0
+
+
+# `ssh root@host '<script>'` and the two forms the docs actually use for it: the
+# kiosk-ssh.sh wrapper, which is how this repo tells you to reach the device, and
+# a double-quoted script. Matching only bare ssh with single quotes made the
+# whole check inert -- every device command in the tracked docs was in one of the
+# forms it could not see.
+SSH_INVOCATION = re.compile(
+    r"""(?:(?:[\w./-]*/)?kiosk-ssh\.sh|ssh)\s+(?:-\S+\s+)*root@\S+\s+"""
+    r"""(?:'([^']*)'|"([^"]*)")""", re.S)
+
+
+def ssh_commands(text):
+    """Commands invoked through `ssh root@... '<script>'`. Yields (cmd, line)."""
+    for m in SSH_INVOCATION.finditer(text):
+        line = text[:m.start()].count("\n") + 1
+        script = m.group(1) if m.group(1) is not None else m.group(2)
+        # Split on shell separators, then take the leading word of each piece.
+        for piece in re.split(r"[;&|]+|\$\(|\n", script):
+            piece = piece.strip()
+            if not piece:
+                continue
+            word = piece.split()[0]
+            if word.startswith(("-", "$", "#", '"')):
+                continue
+            if "=" in word and not word.startswith("/"):
+                continue
+            name = word.rsplit("/", 1)[-1]
+            if name and name not in NOT_BINARIES and re.fullmatch(r"[A-Za-z0-9_.-]+", name):
+                yield name, line
+
+
+def binary_paths(text):
+    """Backticked absolute paths under a bin directory. Yields (path, line)."""
+    for m in re.finditer(r"`(/[A-Za-z0-9_./@%+-]+)`", text):
+        p = m.group(1)
+        if p.startswith(BIN_PREFIXES) and not p.endswith("/"):
+            yield p, text[:m.start()].count("\n") + 1
+
+
+def check() -> int:
+    top = repo_top()
+    rootfs = find_rootfs(top)
+    if rootfs is None:
+        # Loud, on stdout, and exit 0. A Yocto build is hours and cannot gate a
+        # commit, so the absence of one must not fail anything -- but silence
+        # here would be indistinguishable from a clean run, which is the exact
+        # failure this whole script exists to prevent.
+        print("SKIPPED: no build rootfs under "
+              f"{ROOTFS_GLOB} -- doc-image check did not run")
+        return 0
+
+    binaries, paths = scan_rootfs(rootfs)
+    if binaries is None:
+        print(f"rootfs at {rootfs} carries no binaries -- refusing to report a pass",
+              file=sys.stderr)
+        return 2
+    rc = snapshot(rootfs, top / SNAPSHOT_SCRATCH)
+    if rc:
+        return rc
+
+    docs = tracked_markdown(top)
+    if not docs:
+        print("no git-tracked Markdown files -- discovery is broken, not the docs",
+              file=sys.stderr)
+        return 2
+
+    findings, examined = [], 0
+    for md in docs:
+        text = md.read_text(errors="replace")
+        rel = md.relative_to(top)
+        for name, line in ssh_commands(text):
+            examined += 1
+            if name in binaries:
+                continue
+            findings.append((f"{rel}:{line}", f"ssh root@ runs `{name}`", "not in image"))
+        for p, line in binary_paths(text):
+            examined += 1
+            # By basename, against the bin scan. binary_paths yields only
+            # BIN_PREFIXES paths and PATH_DIRS holds no bin directory, so
+            # `paths` can never carry one of these.
+            if p.rsplit("/", 1)[-1] in binaries:
+                continue
+            findings.append((f"{rel}:{line}", f"names `{p}`", "not in image"))
+
+    seen, unique = set(), []
+    for f in findings:
+        if f[1:] not in seen:
+            seen.add(f[1:])
+            unique.append(f)
+
+    for loc, what, why in unique:
+        print(f"{loc}  {what} -- {why}")
+    # `examined` is reported because a silent extraction failure and a clean
+    # pass are otherwise the same output: both print zero findings.
+    # The build time is printed because a months-old rootfs compares clean
+    # against today's prose, and that drift is what the check exists to catch.
+    built = datetime.fromtimestamp(build_time(rootfs)).strftime("%Y-%m-%d %H:%M")
+    print(f"\n{len(unique)} unresolved, {examined} claims examined "
+          f"against {len(binaries)} binaries in {rootfs} (built {built})")
+    if not examined:
+        # Two causes, indistinguishable from here: the docs genuinely name no
+        # device binary, or the extraction regexes stopped matching. The first
+        # is the expected state of a tree whose facts live in code comments,
+        # which this script does not scan -- failing on it would make the gate
+        # permanently red and get it deleted. So report inertness in the one
+        # place a reader is already looking, and do not claim a pass.
+        print(f"NO CLAIMS: {len(docs)} files carry no `ssh root@` or `kiosk-ssh.sh "
+              "root@` command and no backticked /usr/bin path -- this check is "
+              "inert, verify the extraction before trusting it")
+    return 1 if unique else 0
+
+
+def main() -> int:
+    if len(sys.argv) == 2 and sys.argv[1] == "check":
+        return check()
+    if len(sys.argv) == 4 and sys.argv[1] == "snapshot":
+        return snapshot(Path(sys.argv[2]), Path(sys.argv[3]))
+    print(__doc__.strip().split("\n\n")[1], file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/doc-links.py
+++ b/tools/doc-links.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Validate cross-references: file targets, #anchors, section names, and code citations.
+
+    doc-links.py
+
+Exits non-zero if any reference does not resolve. Four classes are checked:
+
+  [text](path)          -> the file exists
+  [text](path#anchor)   -> the file exists AND has a heading slugging to that anchor
+  file.md §"Heading"    -> the file exists AND carries that exact heading text
+  # See docs/README.md  -> the cited path exists, from ANY tracked text file
+
+The third is what makes the "reference by name, never by number" convention
+enforceable. Ordinal references ("open item 3") are reported separately as
+warnings: they resolve today and silently repoint when a list is reordered,
+which has already happened once in this repo.
+
+The fourth exists because the first three are Markdown-only and the citations
+that go stale most often are not in Markdown: a comment in a `.c`, a `.bb`, a
+justfile or a shell script pointing at a document. Three such citations were
+dangling and had to be found by hand.
+
+Per-class counts are printed rather than one total, so a regex that quietly
+stops matching shows up as a zero instead of disappearing into a sum.
+
+Markdown scope is every git-tracked *.md in the repository, not a directory
+argument; the citation class widens that to every git-tracked file that decodes
+as text. Documentation in this layer lives beside the code it explains, so a
+recipe's README is as much in scope as anything under docs/, and git tracking
+excludes build/ and sources/ for free -- the same discovery ci-guards.sh uses.
+"""
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+LINK = re.compile(r'(?<!\!)\[(?:[^\]]*)\]\(([^)]+)\)')
+# Section-name reference: `file.md` §"Exact Heading"  (quotes may be typographic)
+#
+# The optional `](path)` group is load-bearing. Every section reference in this
+# repo is written as a full Markdown link -- [`file.md`](file.md) §"Heading" --
+# so the link tail sits between the filename and the §. Without that group the
+# pattern never matched ANY reference in the tree, and this check silently
+# validated nothing: a CLAUDE.md reference to a section that did not exist
+# passed `just verify` on 2026-08-13.
+_MARKER = re.compile(r'^(?:[\s#*_\u26d4\u26a0\u2705\u2b50\u2757\u2049\U0001F6A8]|`?\[[^\]]*\]`?)+')
+
+
+def _stem(h):
+    """Heading text with leading markers removed, for prefix matching against
+    the readable stem prose actually cites. Strips emoji, heading punctuation
+    and a leading bracketed tag.
+
+    The bracket branch is deliberately generic and deliberately blunt: it also
+    eats the `[Foo]` of a heading written as a link (`## [Foo](bar)`, leaving
+    `(bar)`) and the leading `_` of `## _private_ field`. No heading in the tree
+    is written either way; a reference that mismatches for that reason is the
+    signal to narrow the pattern, not to rewrite the heading."""
+    return _MARKER.sub('', h.strip()).strip()
+
+
+SECREF = re.compile(r'`?([\w./-]+\.md)`?(?:\]\([^)]*\))?\s*§\s*["“]([^"”]+)["”]')
+HEADING = re.compile(r'^(#{1,6})\s+(.*?)\s*#*$')
+ORDINAL = re.compile(r'\b(?:open )?item\s+#?\d+\b|\bdecision\s+\d+\b|\bfault\s+#?\d+\b'
+                     r'|\bstep[s]?\s+\d+(?:\s*[-–]\s*\d+)?\b', re.I)
+
+# A repo-relative path with an extension, under one of the three directories
+# source files point into. Glob and placeholder characters are matched here and
+# rejected below, so `tools/kiosk-*.sh` is recognised as a pattern rather than
+# silently truncated to something that looks like a path.
+_CITED_PATH = r'(?:docs|tools|justfiles)/[A-Za-z0-9_./+*?<>{}%-]*\.[A-Za-z0-9]+'
+_PLACEHOLDER = set('*?<>{}%')
+
+# Only a path in CITATION FORM is treated as a reference to this tree: one that
+# opens a line or a comment, or follows see/at/in/under/per, an arrow, a label
+# colon, an interpreter word, or an opening bracket or quote.
+#
+# The form is what separates a citation from provenance. Three comments in this
+# tree name a file in the upstream project a recipe was ported from, in the
+# shapes "ported from <path>", "the Raspbian <path>" and "Ported from <path> in
+# the kiosk-reference project". Those paths are correct where they stand, and
+# resolving them here would report three failures no edit to this repository
+# could fix.
+CITATION = re.compile(
+    r'(?:^[\s>]*(?:[#*;]+|//|--)?\s*'
+    r'|\b(?:see|at|in|under|per)\s+'
+    r'|(?:->|→)\s*'
+    r'|:\s+'
+    r'|\b(?:python3?|bash|sh|exec)\s+'
+    r'|[(\[\'"])'
+    r'`?(' + _CITED_PATH + r')', re.I)
+
+
+def slug(text):
+    """GitHub-flavoured heading slug."""
+    s = re.sub(r'`|\*|_', '', text).strip().lower()
+    s = re.sub(r'[^\w\s-]', '', s)
+    return re.sub(r'\s+', '-', s)
+
+
+def headings(path):
+    out = []
+    in_fence = False
+    for line in path.read_text(encoding='utf-8', errors='replace').splitlines():
+        if line.lstrip().startswith('```'):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        m = HEADING.match(line)
+        if m:
+            out.append(m.group(2))
+    return out
+
+
+def _ls_files(top, *args):
+    listing = subprocess.run(['git', 'ls-files', *args], cwd=top,
+                             capture_output=True, text=True, check=True).stdout
+    return sorted(top / line for line in listing.splitlines() if line)
+
+
+def tracked_markdown():
+    """Repo top and its git-tracked *.md files, as absolute paths."""
+    top = Path(subprocess.run(['git', 'rev-parse', '--show-toplevel'],
+                              capture_output=True, text=True, check=True).stdout.strip())
+    return top, _ls_files(top, '--', '*.md')
+
+
+def tracked_text(top):
+    """(path, text) for every git-tracked file that decodes as UTF-8. A strict
+    decode is the filter: it takes the captured oops logs and the recipe sources
+    and leaves out anything binary, without a suffix list to keep current."""
+    for p in _ls_files(top):
+        try:
+            yield p, p.read_text(encoding='utf-8')
+        except (UnicodeDecodeError, OSError):
+            continue
+
+
+def main():
+    root, files = tracked_markdown()
+    # A tree with no tracked Markdown reports "0 references checked" and exits
+    # clean, which is indistinguishable from a passing run. Say so instead.
+    if not files:
+        print('no git-tracked Markdown files -- discovery is broken, not the docs',
+              file=sys.stderr)
+        return 2
+    # Key by resolved path: lookups below resolve, and a mismatch here silently
+    # empties every heading list, which reads as "no such heading" on valid refs.
+    head_cache = {p.resolve(): headings(p) for p in files}
+    broken, warned = [], []
+    # Counted per class, not summed. A total hides a regex that stopped matching:
+    # the SECREF pattern once matched nothing at all and the run still printed a
+    # healthy-looking count, because the file links carried it.
+    n_file = n_anchor = n_section = n_cited = 0
+
+    for f in files:
+        rel = f.relative_to(root)
+        text = f.read_text(encoding='utf-8', errors='replace')
+
+        for lineno, line in enumerate(text.splitlines(), 1):
+            for target in LINK.findall(line):
+                if target.startswith(('http://', 'https://', 'mailto:')):
+                    continue
+                n_file += 1
+                path_part, _, anchor = target.partition('#')
+                if path_part:
+                    tgt = (f.parent / path_part).resolve()
+                    if not tgt.exists():
+                        broken.append(f'{rel}:{lineno}  missing file -> {target}')
+                        continue
+                else:
+                    tgt = f.resolve()
+                if anchor:
+                    n_anchor += 1
+                    known = {slug(h) for h in head_cache.get(tgt, headings(tgt))}
+                    if slug(anchor) not in known:
+                        broken.append(f'{rel}:{lineno}  no such heading -> {target}')
+
+            for tgt_name, heading in SECREF.findall(line):
+                n_section += 1
+                tgt = (f.parent / tgt_name).resolve()
+                if not tgt.exists():
+                    # The captured name comes from the LINK TEXT, which is often
+                    # bare ("README.md") while the real target is relative
+                    # ("../README.md"), so fall back to matching by filename.
+                    tgt = next((p for p in files if p.name == Path(tgt_name).name), None)
+                    # head_cache is keyed by RESOLVED paths; an unresolved
+                    # fallback silently yields an empty heading list and fails
+                    # every reference to that file for the wrong reason.
+                    if tgt is not None:
+                        tgt = tgt.resolve()
+                if tgt is None:
+                    broken.append(f'{rel}:{lineno}  section-ref to missing file -> {tgt_name}')
+                # PREFIX match, after stripping leading markers. Headings here
+                # carry emoji, dates and subtitles ("ROOT CAUSE, 2026-08-13: ...")
+                # while prose cites the readable stem ("ROOT CAUSE"). Demanding
+                # the full string would break every reference on any heading
+                # edit; a prefix still catches the real error -- a reference to a
+                # section that does not exist at all.
+                elif not any(_stem(h).startswith(heading.strip()) for h in head_cache.get(tgt, [])):
+                    broken.append(f'{rel}:{lineno}  section-ref heading not found -> '
+                                  f'{tgt_name} §"{heading}"')
+
+            for m in ORDINAL.finditer(line):
+                if line.lstrip().startswith(('#', '|')):
+                    continue
+                # Use vs mention: a quoted or backticked ordinal is an example
+                # being discussed, not a live reference. The line teaching "never
+                # cite by number" necessarily quotes one, and flagging it invites
+                # someone to "fix" the lesson into vagueness.
+                before_ctx, after_ctx = line[:m.start()], line[m.end():]
+                quoted = (before_ctx.rstrip().endswith(('"', '“', '`', "'"))
+                          and after_ctx.lstrip().startswith(('"', '”', '`', "'")))
+                if not quoted:
+                    warned.append(f'{rel}:{lineno}  ordinal reference: "{m.group(0)}"')
+
+    scanned = 0
+    for f, text in tracked_text(root):
+        scanned += 1
+        rel = f.relative_to(root)
+        for lineno, line in enumerate(text.splitlines(), 1):
+            for m in CITATION.finditer(line):
+                target = m.group(1)
+                if _PLACEHOLDER & set(target):
+                    continue
+                n_cited += 1
+                if not (root / target).exists():
+                    broken.append(f'{rel}:{lineno}  cited path does not exist -> {target}')
+
+    print(f'{n_file} file / {n_anchor} anchor / {n_section} section references '
+          f'across {len(files)} Markdown files')
+    print(f'{n_cited} cited paths across {scanned} tracked text files')
+    if broken:
+        print(f'\nBROKEN ({len(broken)}):')
+        for b in broken:
+            print(f'  {b}')
+    else:
+        print('  all resolve')
+    if warned:
+        print(f'\nORDINAL WARNINGS ({len(warned)}) - resolve today, repoint silently on reorder:')
+        for w in warned:
+            print(f'  {w}')
+    return 1 if broken else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/kiosk-bootprofile.sh
+++ b/tools/kiosk-bootprofile.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Take one boot profile end to end: enable, reboot, wait, pull, analyze, disable.
+#
+#   tools/kiosk-bootprofile.sh root@<host> [outdir] [wait-seconds]
+#
+# The sampler is image content that ships disabled -- it costs ~240ms of the
+# boot it measures, so it is not something to leave on. What it is, what it
+# cannot see, and how to read its output are at
+# meta-wisekiosk/recipes-core/kiosk-bootprof/README.md; this script is only the
+# capture cycle, which is otherwise six commands that have to be issued in order
+# and one file that has to be named exactly right.
+#
+# The off switch is `systemctl disable`, never `rm` -- the README above says
+# why. The wait is not politeness either: nothing exists to fetch before the
+# sampler's window closes, and an SSH session opened during it skews the
+# measurement by the cost quantified in that README. One connection, after.
+#
+# The default outdir is local/: the journal this pulls carries the hostname,
+# addresses and the SSID, and local/ is the gitignored home this repository
+# already reserves for exactly that -- the repository is public and just runs
+# recipes with cwd at its root.
+set -uo pipefail
+
+HOST=${1:?usage: kiosk-bootprofile.sh <ssh-target> [outdir] [wait-seconds]}
+OUTDIR=${2:-local}
+WAIT=${3:-180}
+
+# The analyzer is repo content, so resolve it against this script rather than
+# against cwd. The [outdir] parameter is the tell that this is run from
+# elsewhere, and the analyze step is the last one -- a path failure there has
+# already spent a reboot of the thing under test.
+REPO=$(cd "$(dirname "$0")/.." && pwd)
+
+ssh_opts=(-o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10)
+ssh_dev() { ssh "${ssh_opts[@]}" "$HOST" "$@"; }
+
+mkdir -p "$OUTDIR"
+
+# /data survives a reboot by design, so every earlier profile is still sitting
+# there and `ls -t` will hand one back whether or not the reboot happened. The
+# boot id taken here is what makes a stale sample distinguishable from a fresh
+# one; without it, passing and failing are byte-identical.
+BOOT_BEFORE=$(ssh_dev 'cat /proc/sys/kernel/random/boot_id' | tr -d '\r\n')
+[ -n "$BOOT_BEFORE" ] || { echo "could not read the device's boot id -- refusing to run blind" >&2; exit 1; }
+
+echo "== arming the sampler and rebooting (boot id now $BOOT_BEFORE)"
+ssh_dev 'systemctl enable kiosk-bootprofile' || { echo "could not enable the unit" >&2; exit 1; }
+ssh_dev 'systemctl reboot' > /dev/null 2>&1 || true
+
+echo "== waiting ${WAIT}s without touching the device"
+sleep "$WAIT"
+
+echo "== collecting"
+SAMPLE_REMOTE=""
+BOOT_NOW=""
+for _ in 1 2 3 4 5 6; do
+    BOOT_NOW=$(ssh_dev 'cat /proc/sys/kernel/random/boot_id' | tr -d '\r\n')
+    if [ -z "$BOOT_NOW" ] || [ "$BOOT_NOW" = "$BOOT_BEFORE" ]; then
+        echo "   the device is still on boot $BOOT_BEFORE -- waiting 20s"
+        sleep 20
+        continue
+    fi
+    # Only the expected unmatched-glob message is filtered. A blanket
+    # 2>/dev/null here would hide an unmounted /data exactly as well as it hides
+    # a sample that has not been written yet.
+    NEWEST=$(ssh_dev 'ls -t /data/boot-cpu-io.*.txt' 2>&1 \
+        | grep -v 'No such file or directory' | head -n1 | tr -d '\r')
+    # The sampler names its file after the boot it measured (kiosk-bootprof.c
+    # writes "<out_path>.<boot-id>.txt"), so the NAME carries the proof and is
+    # stronger than an mtime. Anything else is a leftover from an earlier boot.
+    if [ "$NEWEST" = "/data/boot-cpu-io.$BOOT_NOW.txt" ]; then
+        SAMPLE_REMOTE=$NEWEST
+        break
+    fi
+    [ -n "$NEWEST" ] && echo "   device answered: $NEWEST -- not the sample for boot $BOOT_NOW"
+    echo "   no sample for this boot yet; the sampler writes once at uptime 150 -- waiting 20s"
+    sleep 20
+done
+[ -n "$SAMPLE_REMOTE" ] || {
+    echo "no /data/boot-cpu-io.$BOOT_NOW.txt appeared -- a sample from an earlier boot is not a profile of this one" >&2
+    exit 1
+}
+
+STEM=$(basename "$SAMPLE_REMOTE" .txt)
+BOOT_ID=${STEM#boot-cpu-io.}
+
+scp "${ssh_opts[@]}" "$HOST:$SAMPLE_REMOTE" "$OUTDIR/$STEM.txt" > /dev/null \
+    || { echo "could not fetch $SAMPLE_REMOTE" >&2; exit 1; }
+
+# The analyzer derives every window edge from a journal it finds by NAME:
+# <same-stem>.journal.txt beside the samples. Get the name wrong and it falls
+# back to hardcoded defaults, which are wrong the moment anything moves -- and
+# it says so only in one word of its own output. Naming it here is why this is a
+# script and not a paragraph.
+#
+# `journalctl -b` wants the boot ID with the dashes stripped. `-b -1` does not
+# work on this image at all: every boot shares a pre-timesync first-entry
+# timestamp, so "the previous boot" is not identifiable that way.
+JOURNAL_ID=${BOOT_ID//-/}
+ssh_dev "journalctl -b $JOURNAL_ID -o short-monotonic" > "$OUTDIR/$STEM.journal.txt" \
+    || { echo "could not read the journal for boot $JOURNAL_ID" >&2; exit 1; }
+[ -s "$OUTDIR/$STEM.journal.txt" ] || { echo "journal for boot $JOURNAL_ID is empty" >&2; exit 1; }
+
+echo "== disarming"
+ssh_dev 'systemctl disable kiosk-bootprofile' || echo "WARNING: the unit is still enabled" >&2
+
+echo "== analyzing"
+python3 "$REPO/meta-wisekiosk/recipes-core/kiosk-bootprof/files/analyze-boot-cpu-io.py" "$OUTDIR/$STEM.txt"

--- a/tools/kiosk-find.sh
+++ b/tools/kiosk-find.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Find a Raspberry Pi on a LAN whose address you do not know.
+#
+#   tools/kiosk-find.sh 192.0.2.0/24
+#
+# Sweeps the /24 with one-packet pings to populate the local ARP cache, then
+# reads that cache back for Raspberry Pi OUIs. The pings are backgrounded and
+# their results discarded on purpose -- the answer is the ARP entry each one
+# leaves behind, not whether it replied.
+#
+# A device missing from the router's client list is not necessarily offline:
+# those lists are built from DHCP leases, so a static or long-leased host can be
+# invisible there and perfectly reachable here.
+set -uo pipefail
+
+CIDR=${1:?usage: kiosk-find.sh <cidr>, e.g. 192.0.2.0/24}
+
+# Raspberry Pi Trading / Raspberry Pi Foundation OUIs. Ordered oldest first;
+# a board absent from this list is not necessarily not a Pi, so a miss means
+# "look at the whole ARP table", not "it is not there".
+OUIS="b8:27:eb dc:a6:32 e4:5f:01 28:cd:c1 2c:cf:67"
+
+case "$CIDR" in
+    *.*.*.*/24) ;;
+    *) echo "only a /24 is swept: give <a.b.c.0>/24, not $CIDR" >&2; exit 2 ;;
+esac
+PREFIX=${CIDR%.*/24}
+
+command -v arp > /dev/null || { echo "arp not installed on this host" >&2; exit 2; }
+
+echo "sweeping $PREFIX.1-254 ..."
+for i in $(seq 1 254); do
+    ping -c1 -W1 "$PREFIX.$i" > /dev/null 2>&1 &
+done
+wait
+
+# `arp -a` prints MACs colon-separated on Linux and dash-separated on some
+# other hosts; matching either keeps this working off a Windows-ish shell too.
+pattern=$(printf '%s' "$OUIS" | tr ' ' '\n' | sed 's/:/[:-]/g' | paste -sd'|' -)
+hits=$(arp -a | grep -Ei "$pattern") || true
+
+if [ -z "$hits" ]; then
+    echo "no Raspberry Pi OUI in the ARP cache for $PREFIX.0/24"
+    echo "the full cache follows -- a newer board may carry an OUI this list predates"
+    arp -a
+    exit 1
+fi
+printf '%s\n' "$hits"

--- a/tools/kiosk-screenshot.sh
+++ b/tools/kiosk-screenshot.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Capture what the kiosk is actually showing, and read the capture correctly.
+#
+#   tools/kiosk-screenshot.sh root@<host> [out.png]
+#
+# `import -window root` (imagemagick) is the capture path this image carries.
+# There is no scrot and no fbgrab: fbgrab was dropped on a misdiagnosis and
+# never restored -- see docs/issue_investigation/screenshot_capture_fbgrab/README.md
+# before proposing either back.
+#
+# DISPLAY=:0 on the remote command: nothing puts DISPLAY into an SSH session on
+# this image -- /etc/environment is empty, the pam_env DISPLAY line is commented
+# out, and sshd has PermitUserEnvironment off. Without it `import` exits with
+# "unable to open X server". Xorg is started by plain xinit with no -auth and
+# there is no /home/pi and no .Xauthority, so :0 alone is also sufficient; the
+# same reasoning is at
+# meta-wisekiosk/recipes-core/kiosk-bootprof/files/measure-surf.sh.
+#
+# /data, not /tmp: /tmp is tmpfs and the staged file would not survive a reboot
+# racing the capture. The remote file is removed once it is here.
+#
+# The default output goes under local/: a capture is a picture of the site's
+# live kiosk page, and local/ is the gitignored home this repository already
+# reserves for exactly that -- the repository is public and just runs recipes
+# with cwd at its root.
+#
+# Reading it:
+#
+#   rgb min=0 max=255 mean~4    healthy -- black background, sparse light text.
+#                               A mean near zero is NORMAL and is not evidence
+#                               of a blank screen.
+#   min == max                  every pixel identical: blank. This is the blank
+#                               test, not the mean.
+#
+# A capture cannot tell you the render is LIVE. Every process-level check would
+# look identical against a screen frozen for hours -- so the device's own clock
+# is taken in the same SSH invocation as the capture, and the point of the
+# exercise is comparing it against the clock the page renders. That is why this
+# script refuses to overwrite an existing file: a stale PNG next to a fresh
+# timestamp is the exact false pass it exists to prevent.
+set -uo pipefail
+
+HOST=${1:?usage: kiosk-screenshot.sh <ssh-target> [out.png]}
+OUT=${2:-local/kiosk-$(date +%Y%m%d-%H%M%S).png}
+
+ssh_opts=(-o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10)
+
+mkdir -p "$(dirname "$OUT")" || { echo "cannot create $(dirname "$OUT")" >&2; exit 1; }
+
+[ -e "$OUT" ] && { echo "$OUT exists -- refusing to overwrite a capture you may be about to read as fresh" >&2; exit 1; }
+
+REMOTE=/data/kiosk-screenshot.$$.png
+
+# Clock and capture in ONE invocation: two invocations put an unknown gap
+# between the reference time and the pixels it is supposed to date.
+DEVICE_TIME=$(ssh "${ssh_opts[@]}" "$HOST" "date '+%H:%M:%S'; DISPLAY=:0 import -window root $REMOTE") || {
+    echo "capture failed on the device" >&2; exit 1; }
+
+scp "${ssh_opts[@]}" "$HOST:$REMOTE" "$OUT" > /dev/null || { echo "could not fetch $REMOTE" >&2; exit 1; }
+ssh "${ssh_opts[@]}" "$HOST" "rm -f $REMOTE" || true
+
+[ -s "$OUT" ] || { echo "$OUT is empty -- the capture did not survive the copy" >&2; exit 1; }
+
+echo "device clock at capture: $DEVICE_TIME"
+echo "wrote $OUT"
+
+# identify is optional on the workstation, so its absence must not read as a
+# pass: say which check did not run.
+if ! command -v identify > /dev/null; then
+    echo "note: imagemagick not installed here -- min/max/mean NOT checked"
+    exit 0
+fi
+
+# Normalised to 0-255 so the numbers are comparable with the signature above:
+# %[min]/%[max]/%[mean] are reported in the build's quantum range, which is
+# 65535 here, and a mean of 1000 next to a documented "mean~4" reads as a fault.
+read -r MIN MAX MEAN <<< "$(identify -format '%[fx:minima*255] %[fx:maxima*255] %[fx:mean*255]' "$OUT")"
+echo "min=$MIN max=$MAX mean=$MEAN"
+if [ "$MIN" = "$MAX" ]; then
+    echo "BLANK: every pixel identical -- the screen is not rendering"
+    exit 1
+fi
+echo "not blank. Now read the rendered clock against the device clock above,"
+echo "and the fetched data against its live source -- a frozen render passes"
+echo "every other check there is."

--- a/tools/kiosk-ssh.sh
+++ b/tools/kiosk-ssh.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# One SSH connection, reused, for a debugging session made of small commands.
+#
+#   tools/kiosk-ssh.sh root@<host> 'uptime -p'
+#   tools/kiosk-ssh.sh root@<host> 'bash -s' <<'EOF'   # a script, still one round trip
+#   systemctl is-active kiosk
+#   cut -d' ' -f1 /proc/loadavg
+#   EOF
+#   tools/kiosk-ssh.sh root@<host> --close             # drop the master early
+#
+# The key exchange is not free here: it runs on the same saturated 1GHz ARM11
+# core the browser renders on, so per-command handshake cost is kiosk load, not
+# just operator latency. Multiplexing pays that once. Nothing is installed on
+# the device -- the master lives on this host -- so it cannot touch the lifeline.
+#
+# Batch anyway: one `bash -s` heredoc beats ten calls even over a warm master.
+#
+# Three things bite:
+#
+#   * The control socket path caps at ~108 characters, and a path over the cap
+#     fails with `too long for Unix domain socket` on EVERY call including the
+#     first, which reads as a connection failure rather than a path problem.
+#     %C is a hash of (local host, remote host, port, user), so that half is
+#     fixed-length no matter what the target is called. The whole path is
+#     "$HOME/.ssh/kiosk-%C", so $HOME is the one variable component and the
+#     only way back over the cap -- fine on any ordinary home directory, and
+#     the thing to look at first if the cap is ever hit.
+#
+#   * Do not add LogLevel=ERROR to silence the post-quantum banner on cold
+#     connect. The banner is expected noise from this EOL sshd; suppressing it
+#     suppresses genuine connection errors with it -- the same mistake as
+#     2>/dev/null on a probe, which turns a broken check into something
+#     indistinguishable from a broken kiosk.
+#
+#   * A master orphaned by a device reboot is the expected stale case.
+#     ServerAliveInterval/CountMax bound it at ~60s instead of hanging forever.
+#     This path is reasoned, not measured. If commands stop answering after a
+#     reboot, run --close before diagnosing anything else.
+#
+# A backgrounded SSH command often exits 1 even when the work succeeded, so
+# verify by querying state afterwards, never by the exit code.
+set -uo pipefail
+
+HOST=${1:?usage: kiosk-ssh.sh <ssh-target> <command> | <ssh-target> --close}
+shift
+
+CONTROL="$HOME/.ssh/kiosk-%C"
+
+ssh_opts=(
+    -o BatchMode=yes
+    -o StrictHostKeyChecking=no
+    -o UserKnownHostsFile=/dev/null
+    -o ConnectTimeout=10
+    -o ControlMaster=auto
+    -o ControlPath="$CONTROL"
+    -o ControlPersist=30m
+    -o ServerAliveInterval=15
+    -o ServerAliveCountMax=4
+)
+
+if [ "${1:-}" = "--close" ]; then
+    # -O exit against no master is not an error worth failing on: the desired
+    # state is "no master", and that is already true.
+    ssh "${ssh_opts[@]}" -O exit "$HOST" 2>&1 | grep -v 'No such file or directory' || true
+    exit 0
+fi
+
+[ "$#" -gt 0 ] || { echo "usage: kiosk-ssh.sh <ssh-target> <command>" >&2; exit 2; }
+
+exec ssh "${ssh_opts[@]}" "$HOST" "$@"

--- a/tools/kiosk-tcp-state.sh
+++ b/tools/kiosk-tcp-state.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# What the kiosk's browser is doing, inferred from TCP state alone.
+#
+#   tools/kiosk-tcp-state.sh <kiosk-address> [port]
+#
+# Run this ON THE MACHINE SERVING THE PAGE. netstat only sees sockets local to
+# the host it runs on, so pointing it at the kiosk from a third machine reports
+# nothing and reads exactly like a kiosk that is not connecting.
+#
+# This is the read of last resort: the kiosk's correct display is a black
+# background, so "working", "browser crashed", "JavaScript threw" and "X never
+# started" are indistinguishable from the room. Socket state is definite.
+#
+#   no connections                        browser not running, or not attempting
+#   1, ending FIN_WAIT_2 / TIME_WAIT      fetched the HTML only -- scripts never
+#                                         ran, so a parse failure or an ignored
+#                                         module
+#   3, then closed                        fetched HTML and JS, but the scripts
+#                                         did not execute -- CSP, or an early
+#                                         throw
+#   1 ESTABLISHED, sustained              rendering, one multiplexed socket.
+#                                         The healthy state
+#
+# "1" appears twice with opposite meanings: a single connection that CLOSES is
+# failure, one that STAYS established is success. State and persistence
+# discriminate, not the count -- and when the count is what you are reading, ask
+# what the right count is. A row reading "many established, sustained" as a
+# health signal once hid the largest bring-up cost on this device for a whole
+# session; it was one connection per module against a six-per-origin limit.
+set -uo pipefail
+
+ADDR=${1:?usage: kiosk-tcp-state.sh <kiosk-address> [port]}
+PORT=${2:-8080}
+
+command -v netstat > /dev/null || { echo "netstat not installed on this host" >&2; exit 2; }
+
+# The state is the last field of a netstat TCP row. Counting local addresses
+# instead answers a different question and produces a table that never matches
+# the one above.
+out=$(netstat -an | grep "^tcp" | grep "$ADDR" | grep ":$PORT" | awk '{print $NF}' | sort | uniq -c)
+
+echo "$ADDR:$PORT  $(date '+%H:%M:%S')"
+if [ -z "$out" ]; then
+    echo "  no connections"
+else
+    printf '%s\n' "$out" | sed 's/^/  /'
+fi
+
+# Deliberately no exit-code verdict: every line above is evidence for a human,
+# and a script that decided "healthy" from one sample would be asserting
+# persistence it never observed. Run it twice, seconds apart.

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -77,13 +77,49 @@ case "$MODE" in
     cp "$STAGE/etc/machine-id" "$DEST/etc/machine-id"
     chown -R 0:0 "$DEST/config" "$DEST/etc" 2>/dev/null || echo "note: run as root to own the files correctly"
     chmod 0600 "$DEST/config/wpa_supplicant.conf"
+
+    # Verify here, not in a procedure someone is told to follow. The failure
+    # this catches is discovered on the device otherwise, and a card that comes
+    # up unprovisioned has no network, so recovering it means physical access
+    # and a second flash.
+    #
+    # Both checks are of things the WRITE can get wrong, never of a value this
+    # script just wrote from input it already validated: re-counting the ssid=
+    # lines of a heredoc, or re-measuring the length of a machine-id the
+    # 32-hex check above already rejected, is arithmetic on a known quantity and
+    # looks identical whether or not it fails.
+    #
+    #   mode        world-readable wifi credentials on a card that leaves the
+    #               room, and wpa_supplicant will not say a word about it. Fires
+    #               when $DEST is the vfat boot partition rather than ext4
+    #               /data: vfat accepts a chmod and ignores it
+    #   ownership   the chown above is downgraded to a note on failure, so this
+    #               is the check that makes it loud -- files owned by the
+    #               invoking user land the wifi credentials on the device owned
+    #               by uid 1000, the same failure the device branch calls out
+    bad=0
+    say() { printf 'VERIFY FAIL  %s\n' "$*" >&2; bad=1; }
+
+    mode=$(stat -c %a "$DEST/config/wpa_supplicant.conf")
+    [ "$mode" = "600" ] || say "wpa_supplicant.conf is mode $mode, must be 600"
+
+    for f in "$DEST/config/"* "$DEST/etc/machine-id"; do
+        own=$(stat -c %u:%g "$f")
+        [ "$own" = "0:0" ] || say "$f is owned by $own, must be 0:0 -- re-run as root"
+    done
+
+    if [ "$bad" -ne 0 ]; then
+        echo "NOT provisioned -- do not boot this card" >&2
+        exit 1
+    fi
+
     sync
     echo "provisioned $DEST"
     ;;
   device)
     ssh_opts=(-o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10)
-    # tar over stdin: small, one stream, nothing like the sustained transfer that
-    # wedges this board.
+    # tar over stdin: one stream, and a few kilobytes of it. Small enough that
+    # transfer shape is not a consideration here either way.
     # --owner/--group: tar otherwise preserves THIS host's uid/gid, landing the
     # wifi credentials owned by uid 1000 on the device.
     tar -C "$STAGE" --owner=root --group=root --numeric-owner -cf - . | ssh "${ssh_opts[@]}" "$DEST" \

--- a/tools/send-bundle-chunked.sh
+++ b/tools/send-bundle-chunked.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
-# Deliver a large file to the kiosk over SSH without wedging its SDIO/mmc path.
+# Deliver a large file to the kiosk over SSH in synced, resumable chunks.
 #
-# Evidence this is built on (docs/experiment-log.md):
+# SUPERSEDED: the SDIO/mmc wedge this shape works around was a symptom of
+# top-OPP memory corruption, fixed by the clock cap in
+# meta-wisekiosk/recipes-core/kiosk-cpufreq. Kept until removal lands --
+# issue #29 remove chunked bundle delivery.
+#
+# Evidence this was built on, measured on the uncapped board
+# (mechanism: docs/issue_investigation/wifi_instability/README.md):
 #   Test A  334 MB written to /data + sync, negligible network  -> SURVIVED
 #   Test B  133 MB received into /dev/null, zero disk writes    -> HUNG in 11 s
 #   TX      133 MB sent from the device, three runs             -> 2 of 3 HUNG
-# Sustained activity in either direction wedges it, and combining network
-# receive with a synchronous SD write is the worst case: a sync after every
+# Sustained activity in either direction wedged it, and combining network
+# receive with a synchronous SD write was the worst case: a sync after every
 # append made the board hang on the FIRST chunk every time, where the unsynced
 # form moved 14 in a row.
 #


### PR DESCRIPTION
Reworks the docs migration around the review of PR #14 docs migration: **documentation lives alongside the thing that created it, and no fact is stated twice.** Nothing from the old flat `docs/` tree is carried forward as-is; of its ~4,100 lines, most die because the tree already documents them better, and the remainder is re-homed. Part of #12 docs migration tracking.

## Shape
- **`docs/issue_investigation/<issue>/`** — 8 investigations, each exactly: configuration under test / how the test was performed / metrics / changes configured as a result. The "changes" section links to the code carrying the change; it never restates the rationale. Oops captures are filed with their issue.
- **Colocation** — acted-on changes are documented at their recipes (incl. two citation fixes for docs that were already dangling on `main`); procedures became `tools/kiosk-*.sh` + `justfiles/device.just`/`deploy.just` recipes + a `kiosk-debug` skill; repo-level facts merged into the README.
- **Gitignored `local/`** — instance history (inventory, one-off readings, retired plans) lives in the working tree, never published. Diagnostic outputs (backups, boot profiles, screenshots) default there too, since they carry site config and journal content.
- **Doc gate, no escape hatches** — no waiver file, no committed snapshot. `doc-links.py` also gates code-comment citations of repo paths (the class that produced three hand-found dangling citations) and prints per-class counts so a dead regex is visible. `doc-image.py` regenerates its snapshot from the build tree, prints the rootfs age, and announces loudly when it has nothing to check. CI and the pre-commit hook run the link gate; the image gate is local-only (CI never has a rootfs).
- **Tickets, not prose** — every open recommendation became an issue: #17–#29.

## Owner comments from PR #14, one by one
| Comment | Resolution |
|---|---|
| evidence → `issue_investigation/wifi_instability` | Done; both oops captures moved byte-for-byte alongside the investigation. |
| backup-recovery "this device" → gitignored scratchpad | `local/` created + gitignored; instance notes live there. General recovery facts were already on README/recipes and are not restated. |
| boot-profile → split per investigation | `boot_cpu_saturation`, `wlan0_udev_queue`, `first_boot_after_ota`; the profiler tool itself is documented at `recipes-core/kiosk-bootprof/README.md`. |
| browser-constraints → constraints only | Deleted entirely — its one surviving fact was already colocated at the surf kiosk patch. Nothing Raspbian-era carried anywhere. |
| hardening-and-backup-plan retired → local | `local/hardening-and-backup-plan.md`; the root-login gap surfaced as a README known-gap citing issue #7 debug-tweaks empty root password. |
| image-migration = changelog from git history | Deleted. Three non-derivable facts re-homed (dbus hop → recipe comment; two leftovers → issues #22, #23). |
| image-trim L52/L76/L1 | Three-way split: ~30 acted-on rows deleted as already colocated at their recipes; open items → issues #19 #20 #21 #22 #23; the two genuinely closed routes kept as `webkit_dependency_trims` (flat statements, no correction arc). |
| mirror-deployment → README | One de-identified sentence in the README intro; the rest documented an external system this repo does not build. |
| pi-inventory → gitignored notes | `local/pi-inventory.md`, trimmed of everything already public. |
| provisioning L1/L71/L143 | `provision-fresh-card` recipe added (the one genuine gap); verification moved *into* `tools/provision.sh` so it cannot be skipped — and rewritten so each check can actually fail (ownership, not re-measuring values the script just wrote). Raspbian section deleted outright. No Claude skill for provisioning — it is one script and two recipes, not an interactive workflow; flagging that as a deliberate call, say the word and it gets one. |
| remote-debugging → skills/scripts | Five `tools/kiosk-*.sh` + six recipes + `.claude/skills/kiosk-debug/SKILL.md`. The two real investigations inside it became `surf_memory_soak` and `screenshot_capture_fbgrab`. |
| service-changes → alongside the changes | Deleted outright; every row was already at its recipe. Residues: issue #26 watchdog/boot-counter, one busybox-`nc` comment at `kiosk-launch`. |
| yocto-ota-plan → should not exist | Deleted; the repo already says what it built. Residues: issues #24, #25, and the `first_boot_after_ota` investigation. |
| doc-image-waivers allowlist | Not ported; waiver plumbing deleted. Each entry's underlying claim was fixed or re-homed — including correcting a false claim about rxvt-unicode (it *is* in the image, via xinit's RDEPENDS, installed as `/usr/bin/rxvt*`, which is why greps for "urxvt" miss it). |
| image-snapshot.json committed/drift-prone | Not ported; regenerated in-process into gitignored `build/`, never a silent pass. |

## Chunked delivery is superseded (owner, 2026-08-14)
The SDIO-wedge premise is retired: root cause was top-OPP memory corruption, fixed by the `kiosk-cpufreq` clock cap. README, `ota.just` and the chunker's own header now say so in one line each; removal (and re-verifying plain transfers on the capped board) is issue #29 remove chunked bundle delivery. The removal itself is deliberately not in this PR — it touches the OTA path of the live board.

## Verification
- `just guards` green (incl. gitleaks over full history); `just verify` green: 50 file / 0 anchor / 0 section doc references + 52 code-comment citations, all resolve; doc-image ran against the real rootfs (built 2026-08-14) and reports NO CLAIMS loudly.
- Every new gate was proven able to fail with a seeded defect *and* a valid-but-unusually-spelled variant: doc-links (both classes), provision.sh ownership check, ci-guards' sweep of the new scripts, the bootprofile staleness guard (incl. a pre-fix counterfactual that wrongly passed).
- Independent review: five fresh-context audits (comment compliance, duplication/loss, code, publication safety, link/structure) produced 11 blockers + 15 majors; all fixed and re-verified, including a real METAR station ID that would have fingerprinted the kiosk's location, a screenshot script that could never capture (no `DISPLAY` over SSH), and diagnostic outputs that would have landed unignored in the public tree.

## Flagged for the owner (defaults chosen, easy to reverse)
1. `doc-image.py` currently examines **zero** claims — the rework moved device commands into scripts it does not scan. It lands anyway (loud about its own inertness), but consider dropping it if it stays inert.
2. Eight investigation dirs for a one-device repo; `netcheck_nolan_recovery` and `screenshot_capture_fbgrab` are the thinnest and can collapse into code comments on request.
3. The n≥3 / state-the-mechanism / state-the-revert measurement convention is de facto in every recipe comment but written down nowhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URcEwcTUTS1yDHBRGZq5DS
