### PR TITLE
tools: verified-functional device tooling (discovery, flash, provisioning)

### DIFF
--- a/.claude/skills/kiosk-debug/SKILL.md
+++ b/.claude/skills/kiosk-debug/SKILL.md
@@ -19,14 +19,17 @@ something definite.
 
 | Question | Reach for | Why this one |
 |---|---|---|
-| Is the browser fetching the page at all, and did its scripts run? | [`tools/kiosk-tcp-state.sh`](../../../tools/kiosk-tcp-state.sh) | Socket state distinguishes "never connected", "fetched HTML only" and "rendering" without touching the device. Needs no access to the kiosk — run it on the host serving the page. |
+| Is the browser fetching the page at all, and did its scripts run? | [`tools/kiosk-tcp-state.sh`](../../../tools/kiosk-tcp-state.sh) | Socket state distinguishes "never connected", "fetched HTML only" and "rendering" without touching the device. Needs no access to the kiosk — run it on the host serving the page, because a socket table only holds that host's own sockets. Reads `ss`, falling back to `netstat`, and prints which; state names are canonicalised to the spelling the script's own header table uses — neither engine's — so the table matches the output either way. |
 | Is the screen showing the right thing, right now? | [`tools/kiosk-screenshot.sh`](../../../tools/kiosk-screenshot.sh) | The only check that can catch a *frozen* render. Nothing process-level can. |
 | Is memory flat, or climbing over hours? | `kiosk-soak.sh --summary` on the device, via [`tools/kiosk-ssh.sh`](../../../tools/kiosk-ssh.sh) | The sampler already runs; the answer is in `/data/kiosk-soak.log`, and its own header says how to read it. |
 | Where is boot time going, and would reordering work help? | [`tools/kiosk-bootprofile.sh`](../../../tools/kiosk-bootprofile.sh) | Only source of per-window CPU/I-O and the module timeline. Costs a reboot and ~3 minutes. |
-| The device is not answering and its address is unknown | [`tools/kiosk-find.sh`](../../../tools/kiosk-find.sh) | The router's client list is DHCP leases, so a reachable host can be missing from it. |
+| The device is not answering and its address is unknown | [`tools/kiosk-find.sh`](../../../tools/kiosk-find.sh) | The router's client list is DHCP leases, so a reachable host can be missing from it. Identifying a board needs its MAC, so the script picks the best L2 view it has — Windows interop under WSL, a local interface otherwise — and names it, because under WSL2's NAT this host's own neighbour table never holds a LAN peer. |
 
 Reach for the cheapest instrument that can *fail*. TCP state and a screenshot cost seconds and
 no reboot; a boot profile costs a boot of the thing you are debugging.
+
+Screenshot, soak read, and boot profile all need a device that answers SSH. Each script's own
+header says what its device-side step requires and what can be checked without one.
 
 Every one of these opens an SSH connection to the device, so batch reads through `kiosk-ssh.sh`
 rather than issuing them one at a time; its header says what a connection costs and how it is
@@ -35,9 +38,12 @@ reused. During a boot profile the connection is itself an instrument — see
 
 ## Ordering a diagnosis
 
-1. **Is it reachable?** If not, `kiosk-find.sh` on the LAN before assuming it is down — and if
-   it answers there but not over SSH, close a stale multiplex master (`kiosk-ssh.sh <host>
-   --close`) before diagnosing anything else.
+1. **Is it reachable?** If not, `kiosk-find.sh` on the LAN before assuming it is down — the
+   board may have taken a different address, and the script reports every Pi OUI it sees with
+   whether tcp/22 answers, so a re-addressed device looks nothing like an absent one. If it
+   answers there but not over SSH, close a stale multiplex master (`kiosk-ssh.sh <host>
+   --close`) before diagnosing anything else. Read the `L2 view:` line first: on `none` the run
+   proves only which addresses replied, never that a silent one is unused.
 2. **Is it rendering?** `kiosk-screenshot.sh`. A blank result and a correct-but-stale result are
    different faults with the same appearance, which is why the script takes the device clock in
    the same call as the pixels.

--- a/Justfile
+++ b/Justfile
@@ -20,6 +20,14 @@ config := env('KAS_CONFIG', 'kiosk-zero-w.yaml')
 # Image name for flash recipe
 image-name := "core-image-base"
 
+# The device every host-defaulting recipe talks to, in ssh target form. This is
+# a hardware-in-the-loop unit and boards get swapped, so the address is the one
+# thing here guaranteed to go stale -- it is defined once and overridden by the
+# environment (`export KIOSK_HOST=root@<addr>`) rather than edited per recipe.
+# `just find <cidr>` is how you learn the address of a board you just swapped in.
+# tools/send-bundle-chunked.sh reads KIOSK_HOST itself and needs no plumbing.
+kiosk-host := env('KIOSK_HOST', 'root@192.168.1.6')
+
 # === RAUC Configuration ===
 
 # Directory for RAUC bundles
@@ -117,7 +125,7 @@ image:
 # Write per-site config to a device's /data. The image carries none of it.
 [group('provision')]
 [doc("Provision a reachable device's /data from secrets.yaml")]
-provision-device host="root@192.168.1.6":
+provision-device host=kiosk-host:
     tools/provision.sh device {{host}}
 
 # Before first boot: the wifi credentials are what let you reach the device, so

--- a/README.md
+++ b/README.md
@@ -89,15 +89,19 @@ overscan, UART) are free to change.
 ### Flashing a card
 
 ```sh
-# build/tmp-raspberrypi0-wifi/deploy/images/raspberrypi0-wifi/*.wic.bz2
-bzcat <image>.wic.bz2 | sudo dd of=/dev/sdX bs=4M conv=fsync status=progress
-
-# the image carries NO site config; provision the card before first boot
-tools/provision.sh card /mnt/data
+just flash /dev/sdX                 # writes build/.../*.wic.bz2, re-reads the partition table
+just provision-fresh-card /dev/sdX  # mounts partition 4, writes the site config, unmounts
 ```
 
 The card must be provisioned before it boots. WiFi credentials are what let you reach the device, so
 the first write cannot come over the network.
+
+`/data` is the **fourth** partition, and nothing on the card says so — the layout is boot, rootfs-a,
+rootfs-b, data. `provision-fresh-card` derives it; provisioning by hand instead
+(`tools/provision.sh card <mountpoint>`) means picking that partition yourself, and picking the
+rootfs or the vfat boot partition leaves a unit that boots with no network and no way in but a USB
+keyboard. `tools/provision.sh` refuses either — vfat cannot hold the 0600 the wifi credentials need,
+and a non-root run leaves them owned by the wrong uid — but only after the card is already written.
 
 ### Updating a running device
 
@@ -106,6 +110,12 @@ just kiosk-ota      # bundle -> preflight -> chunked send -> rauc install
 just kiosk-reboot
 just kiosk-rollback # if the new slot comes up wrong
 ```
+
+Every recipe that defaults to a device — `kiosk-ota`, `kiosk-send`, `kiosk-install`, `kiosk-reboot`,
+`kiosk-rollback`, `kiosk-preflight`, `kiosk-backup`, `provision-device` — takes its default from one
+`kiosk-host` variable in the [`Justfile`](Justfile), so `export KIOSK_HOST=root@<addr>` retargets all
+of them at once. Boards get swapped on this unit; `just find <cidr>` is how you learn the address of
+the one now on the bench. An explicit `host` argument still wins over both.
 
 `kiosk-preflight` refuses a delivery that cannot work — wrong slot size, stale bundle, no room on
 `/data` — before spending twenty-five minutes transferring it. The chunked transfer is a superseded

--- a/justfiles/deploy.just
+++ b/justfiles/deploy.just
@@ -8,6 +8,14 @@
 [group('deploy')]
 [script('bash')]
 flash device:
+    # errexit+pipefail, because the write is the whole point: without them a
+    # failed `dd` -- sudo unable to authenticate, a card pulled mid-copy -- still
+    # reaches the closing "Done. Safe to eject", and an unwritten card is
+    # indistinguishable from a written one until it fails to boot.
+    set -euo pipefail
+    # sudo consults SUDO_ASKPASS only under -A. Without it, every root step here
+    # dies on a host with no controlling terminal (CI, a hook, an agent shell).
+    if [ -n "${SUDO_ASKPASS:-}" ]; then SUDO=(sudo -A); else SUDO=(sudo); fi
     IMAGE="build/tmp-{{machine}}/deploy/images/{{machine}}/{{image-name}}-{{machine}}.rootfs.wic.bz2"
     if [ ! -b "{{device}}" ]; then
         echo "Error: Device not found or not a block device: {{device}}"
@@ -20,25 +28,32 @@ flash device:
     fi
     echo "Flashing $IMAGE to {{device}}..."
     echo "WARNING: This will overwrite all data on {{device}}!"
-    read -p "Continue? [y/N] " -n 1 -r
+    # `|| true`: read exits non-zero at EOF, which errexit would turn into an
+    # abort that reads like a decline. An empty REPLY declines on its own.
+    read -p "Continue? [y/N] " -n 1 -r || true
     echo
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    if [[ ! ${REPLY:-} =~ ^[Yy]$ ]]; then
         echo "Aborted."
         exit 1
     fi
     if command -v bmaptool &> /dev/null; then
         BMAP="${IMAGE%.bz2}.bmap"
         if [ -f "$BMAP" ]; then
-            sudo bmaptool copy --bmap "$BMAP" "$IMAGE" {{device}}
+            "${SUDO[@]}" bmaptool copy --bmap "$BMAP" "$IMAGE" {{device}}
         else
             echo "Warning: bmap file not found, bmaptool will be slower"
-            sudo bmaptool copy "$IMAGE" {{device}}
+            "${SUDO[@]}" bmaptool copy "$IMAGE" {{device}}
         fi
     else
         echo "bmaptool not found, falling back to dd (slower)..."
-        bzcat "$IMAGE" | sudo dd of={{device}} bs=4M status=progress conv=fsync,sparse
+        bzcat "$IMAGE" | "${SUDO[@]}" dd of={{device}} bs=4M status=progress conv=fsync,sparse
     fi
     sync
+    # The kernel holds the partition table it read at plug time, so the card's
+    # new partitions -- including the fourth, /data -- do not exist as device
+    # nodes yet, and `just provision-fresh-card` would report the card unflashed.
+    "${SUDO[@]}" blockdev --rereadpt {{device}} || echo "Warning: could not re-read the partition table -- replug the card before provisioning"
+    udevadm settle 2>/dev/null || true
     echo "Done. Safe to eject {{device}}."
 
 # Provision a freshly flashed card: mount /data, write the site config, unmount
@@ -56,6 +71,9 @@ flash device:
 [doc("Mount a fresh card's /data, provision it from secrets.yaml, unmount")]
 provision-fresh-card device mountpoint="/mnt/kiosk-data":
     set -uo pipefail
+    # sudo consults SUDO_ASKPASS only under -A, and a host with no controlling
+    # terminal has no other way to answer the prompt.
+    if [ -n "${SUDO_ASKPASS:-}" ]; then SUDO=(sudo -A); else SUDO=(sudo); fi
     case "{{device}}" in
         *mmcblk*|*nvme*) PART="{{device}}p4" ;;
         *)               PART="{{device}}4"  ;;
@@ -64,11 +82,11 @@ provision-fresh-card device mountpoint="/mnt/kiosk-data":
         echo "Error: $PART is not a block device -- flash the card first, and check the device name"
         exit 1
     fi
-    sudo mkdir -p {{mountpoint}}
-    sudo mount "$PART" {{mountpoint}} || { echo "could not mount $PART"; exit 1; }
+    "${SUDO[@]}" mkdir -p {{mountpoint}}
+    "${SUDO[@]}" mount "$PART" {{mountpoint}} || { echo "could not mount $PART"; exit 1; }
     # umount on every exit path: an unmounted-but-still-mounted card gets pulled
     # out with the config still in page cache.
-    trap 'sudo umount {{mountpoint}} || echo "WARNING: {{mountpoint}} is still mounted"' EXIT
+    trap '"${SUDO[@]}" umount {{mountpoint}} || echo "WARNING: {{mountpoint}} is still mounted"' EXIT
     # Root is needed to own the written files, but sudo resets HOME, so the
     # secrets path is resolved as the invoking user and passed through.
-    sudo KIOSK_SECRETS="${KIOSK_SECRETS:-$HOME/.config/wisekiosk/secrets.yaml}" tools/provision.sh card {{mountpoint}}
+    "${SUDO[@]}" KIOSK_SECRETS="${KIOSK_SECRETS:-$HOME/.config/wisekiosk/secrets.yaml}" tools/provision.sh card {{mountpoint}}

--- a/justfiles/device.just
+++ b/justfiles/device.just
@@ -43,14 +43,29 @@ status host:
 # given symptom calls for.
 
 # Takes a CIDR rather than a host: this is the recipe for when the address is
-# what you are missing.
+# what you are missing. The script picks its own L2 view -- Windows interop
+# under WSL, a local interface otherwise -- and prints which one it used,
+# because a miss means something different in each.
+#
+# Exit 3 stays non-zero: it means "no L2 view, nothing could be identified", and
+# a caller that read that as "the subnet is empty" is the exact mistake this
+# recipe exists to prevent. But a rc=3 run can still have printed useful
+# addresses above, and just's bare "error: recipe find failed" describes none of
+# that, so the line below names what 3 means before just says its piece.
 [group('device')]
-[doc("Ping-sweep a /24 and report Raspberry Pi OUIs from the ARP cache")]
+[script('bash')]
+[doc("Sweep a /24 and report Raspberry Pi OUIs from the best neighbour table available")]
 find cidr:
     tools/kiosk-find.sh {{cidr}}
+    rc=$?
+    if [ $rc -eq 3 ]; then
+        echo "exit 3: no L2 view of {{cidr}}. Anything printed above is reachability only," >&2
+        echo "        not an identification, and no line of it says the subnet is empty." >&2
+    fi
+    exit $rc
 
-# Run from the host serving the page -- netstat only sees its own sockets, so
-# the address to pass is the KIOSK's, not this host's.
+# Run from the host serving the page -- a socket table only holds that host's
+# own sockets, so the address to pass is the KIOSK's, not this host's.
 [group('device')]
 [doc("Infer browser state from TCP connections to the served page")]
 tcp-state kiosk-addr port="8080":
@@ -86,14 +101,20 @@ bootprofile host outdir="local":
 # is part of #29 remove chunked bundle delivery; until then gzip -t below is
 # what says whether the transfer arrived whole.
 #
+# The pull itself needs a reachable device. What runs without one: mkdir, the
+# overwrite guard, and gzip -t catching a truncated (here, empty) stream.
+#
 # The tarball lands in local/: it holds /data/config/wpa_supplicant.conf and the
 # persistent journal, and local/ is this repository's gitignored home for
 # exactly that. just runs recipes with cwd at the repository root, which is
 # public.
+#
+# host is an ssh target, `root@<addr>`, not a bare address: it defaults to
+# kiosk-host, which every other host-defaulting recipe shares.
 [group('device')]
 [script('bash')]
 [doc("Pull a dated tarball of the device's /data to this host")]
-kiosk-backup host="192.168.1.6":
+kiosk-backup host=kiosk-host:
     SSH="ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
     mkdir -p local
     OUT="local/kiosk-data-$(date +%F).tar.gz"
@@ -101,7 +122,7 @@ kiosk-backup host="192.168.1.6":
         echo "$OUT exists -- move it aside rather than overwriting today's backup"
         exit 1
     fi
-    $SSH root@{{host}} 'tar -czf - -C / data' > "$OUT"
+    $SSH {{host}} 'tar -czf - -C / data' > "$OUT"
     # A truncated stream still leaves a file, and gzip is where that shows up.
     gzip -t "$OUT" || { echo "$OUT does not decompress -- the transfer was cut short"; rm -f "$OUT"; exit 1; }
     echo "wrote $OUT ($(du -h "$OUT" | cut -f1))"

--- a/justfiles/ota.just
+++ b/justfiles/ota.just
@@ -146,7 +146,7 @@ kiosk-bundle kconfig="kiosk-zero-w.yaml":
 [group('ota')]
 [script('bash')]
 [doc("Refuse a delivery that cannot work: slot size, stale bundle, /data space")]
-kiosk-preflight image="build/tmp-raspberrypi0-wifi/deploy/images/raspberrypi0-wifi/core-image-base-raspberrypi0-wifi.rootfs.ext4" bundle="build/tmp-raspberrypi0-wifi/deploy/images/raspberrypi0-wifi/update-bundle-raspberrypi0-wifi.raucb" host="root@192.168.1.6":
+kiosk-preflight image="build/tmp-raspberrypi0-wifi/deploy/images/raspberrypi0-wifi/core-image-base-raspberrypi0-wifi.rootfs.ext4" bundle="build/tmp-raspberrypi0-wifi/deploy/images/raspberrypi0-wifi/update-bundle-raspberrypi0-wifi.raucb" host=kiosk-host:
     set -euo pipefail
     SSH="ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
 
@@ -197,14 +197,14 @@ kiosk-preflight image="build/tmp-raspberrypi0-wifi/deploy/images/raspberrypi0-wi
 [group('ota')]
 [script('bash')]
 [doc("Deliver a bundle in chunked bursts, verified end to end")]
-kiosk-send bundle="build/tmp-raspberrypi0-wifi/deploy/images/raspberrypi0-wifi/update-bundle-raspberrypi0-wifi.raucb" host="root@192.168.1.6" chunk_mb="8" rx_pause="2" sync_pause="2":
+kiosk-send bundle="build/tmp-raspberrypi0-wifi/deploy/images/raspberrypi0-wifi/update-bundle-raspberrypi0-wifi.raucb" host=kiosk-host chunk_mb="8" rx_pause="2" sync_pause="2":
     KIOSK_HOST={{host}} tools/send-bundle-chunked.sh {{bundle}} {{chunk_mb}} {{rx_pause}} {{sync_pause}}
 
 # Does NOT reboot -- inspect `rauc status` first, then `just kiosk-reboot`.
 [group('ota')]
 [script('bash')]
 [doc("Install a staged bundle and show slot state")]
-kiosk-install host="root@192.168.1.6":
+kiosk-install host=kiosk-host:
     SSH="ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
     echo "== before"
     $SSH {{host}} 'fw_printenv BOOT_ORDER BOOT_A_LEFT BOOT_B_LEFT; rauc status 2>&1 | grep -E "Booted|Activated|boot status"'
@@ -233,7 +233,7 @@ kiosk-install host="root@192.168.1.6":
 # Reboot and wait for the kiosk to answer again.
 [group('ota')]
 [script('bash')]
-kiosk-reboot host="root@192.168.1.6":
+kiosk-reboot host=kiosk-host:
     SSH="ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
     BEFORE=$($SSH {{host}} 'cat /proc/sys/kernel/random/boot_id' 2>/dev/null)
     $SSH {{host}} 'systemctl reboot' >/dev/null 2>&1 || true
@@ -249,7 +249,7 @@ kiosk-reboot host="root@192.168.1.6":
 
 # Full Tier 1 OTA. Builds the bundle FIRST so a stale .raucb cannot be shipped.
 [group('ota')]
-kiosk-ota host="root@192.168.1.6" kconfig="kiosk-zero-w.yaml": (kiosk-bundle kconfig) (kiosk-preflight "build/tmp-raspberrypi0-wifi/deploy/images/raspberrypi0-wifi/core-image-base-raspberrypi0-wifi.rootfs.ext4" "build/tmp-raspberrypi0-wifi/deploy/images/raspberrypi0-wifi/update-bundle-raspberrypi0-wifi.raucb" host) (kiosk-send "build/tmp-raspberrypi0-wifi/deploy/images/raspberrypi0-wifi/update-bundle-raspberrypi0-wifi.raucb" host) (kiosk-install host)
+kiosk-ota host=kiosk-host kconfig="kiosk-zero-w.yaml": (kiosk-bundle kconfig) (kiosk-preflight "build/tmp-raspberrypi0-wifi/deploy/images/raspberrypi0-wifi/core-image-base-raspberrypi0-wifi.rootfs.ext4" "build/tmp-raspberrypi0-wifi/deploy/images/raspberrypi0-wifi/update-bundle-raspberrypi0-wifi.raucb" host) (kiosk-send "build/tmp-raspberrypi0-wifi/deploy/images/raspberrypi0-wifi/update-bundle-raspberrypi0-wifi.raucb" host) (kiosk-install host)
     @echo "Delivered and installed. Verify, then: just kiosk-reboot {{host}}"
 
 # The [doc] attribute rather than a trailing comment: just takes the LAST
@@ -264,7 +264,7 @@ kiosk-ota host="root@192.168.1.6" kconfig="kiosk-zero-w.yaml": (kiosk-bundle kco
 [group('ota')]
 [script('bash')]
 [doc("Roll back to the other slot")]
-kiosk-rollback host="root@192.168.1.6":
+kiosk-rollback host=kiosk-host:
     SSH="ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
     $SSH {{host}} 'rauc status mark-bad booted; fw_printenv BOOT_ORDER BOOT_A_LEFT BOOT_B_LEFT'
     echo "Marked booted slot bad. Now: just kiosk-reboot {{host}}"

--- a/tools/kiosk-bootprofile.sh
+++ b/tools/kiosk-bootprofile.sh
@@ -3,6 +3,12 @@
 #
 #   tools/kiosk-bootprofile.sh root@<host> [outdir] [wait-seconds]
 #
+# The six-step cycle below (enable, reboot, wait, collect, disable, analyze)
+# needs a reachable kiosk end to end. What runs without one: argument
+# handling, outdir creation, the ssh failure modes against an unreachable or
+# nonexistent host, and the analyzer's parsing, invoked directly against a
+# sample file.
+#
 # The sampler is image content that ships disabled -- it costs ~240ms of the
 # boot it measures, so it is not something to leave on. What it is, what it
 # cannot see, and how to read its output are at

--- a/tools/kiosk-find.sh
+++ b/tools/kiosk-find.sh
@@ -3,22 +3,47 @@
 #
 #   tools/kiosk-find.sh 192.0.2.0/24
 #
-# Sweeps the /24 with one-packet pings to populate the local ARP cache, then
-# reads that cache back for Raspberry Pi OUIs. The pings are backgrounded and
-# their results discarded on purpose -- the answer is the ARP entry each one
-# leaves behind, not whether it replied.
+# What identifies a Pi is its MAC, and a MAC is visible only to a host on the
+# same broadcast domain. So the script first decides which L2 view it has, then
+# says which one it used -- the three differ in what a miss means:
 #
-# A device missing from the router's client list is not necessarily offline:
-# those lists are built from DHCP leases, so a static or long-leased host can be
-# invisible there and perfectly reachable here.
+#   windows   this host is WSL and the Windows host is on the target LAN. Sweep
+#             and read the neighbour table from the Windows side. WSL2 sits
+#             behind NAT, so its own table never holds a LAN peer no matter how
+#             many packets cross it; only Windows sees the ARP replies.
+#   local     an interface on this host is inside the CIDR. Sweep, then read
+#             `ip neigh` (`arp -a` where iproute2 is absent).
+#   none      no L2 view of that subnet. The sweep still runs, but it can only
+#             report which addresses answer -- it cannot say what they are.
+#
+# Interop that answers the opening probe and then dies mid-run is demoted to
+# `none` as well (exit 3), because that is what it is. Reporting the empty
+# result of calls that never ran as "nothing answered ARP" is a claim about the
+# LAN, and it was observed false with the board sitting on it.
+#
+# The sweep pings every address to provoke the ARP exchange. Ping replies are
+# not the answer and are discarded: the answer is the neighbour entry each
+# exchange leaves behind, which appears even for a host that drops ICMP.
+#
+# A miss is not absence. A device missing from the router's client list may
+# simply hold a static or long-lived lease, a board may carry an OUI newer than
+# the list below, and a host asleep during the sweep leaves no entry. The whole
+# neighbour table is printed on a miss for exactly that reason.
 set -uo pipefail
 
 CIDR=${1:?usage: kiosk-find.sh <cidr>, e.g. 192.0.2.0/24}
 
 # Raspberry Pi Trading / Raspberry Pi Foundation OUIs. Ordered oldest first;
 # a board absent from this list is not necessarily not a Pi, so a miss means
-# "look at the whole ARP table", not "it is not there".
+# "look at the whole neighbour table", not "it is not there".
 OUIS="b8:27:eb dc:a6:32 e4:5f:01 28:cd:c1 2c:cf:67"
+
+# Where the Windows system directory is mounted. WSL's mount point is
+# configurable, and pointing this somewhere that does not exist is also how the
+# no-interop path gets exercised on a machine that has interop.
+WINDIR=${WINDIR_MNT:-/mnt/c/Windows}
+PS_EXE="$WINDIR/System32/WindowsPowerShell/v1.0/powershell.exe"
+ARP_EXE="$WINDIR/System32/ARP.EXE"
 
 case "$CIDR" in
     *.*.*.*/24) ;;
@@ -26,23 +51,243 @@ case "$CIDR" in
 esac
 PREFIX=${CIDR%.*/24}
 
-command -v arp > /dev/null || { echo "arp not installed on this host" >&2; exit 2; }
+# --- probes ---------------------------------------------------------------
 
-echo "sweeping $PREFIX.1-254 ..."
-for i in $(seq 1 254); do
-    ping -c1 -W1 "$PREFIX.$i" > /dev/null 2>&1 &
-done
-wait
+# Run a PowerShell script read from stdin. -EncodedCommand takes UTF-16LE
+# base64, which is the one form that survives the trip through two shells and a
+# Windows command line without any quoting rule applying to it.
+win_ps() {
+    local enc
+    enc=$(iconv -f UTF-8 -t UTF-16LE | base64 -w0) || return 1
+    timeout 90 "$PS_EXE" -NoProfile -NonInteractive -EncodedCommand "$enc" 2>/dev/null | tr -d '\r'
+}
 
-# `arp -a` prints MACs colon-separated on Linux and dash-separated on some
-# other hosts; matching either keeps this working off a Windows-ish shell too.
-pattern=$(printf '%s' "$OUIS" | tr ' ' '\n' | sed 's/:/[:-]/g' | paste -sd'|' -)
-hits=$(arp -a | grep -Ei "$pattern") || true
+# Connect and drop. bash opens /dev/tcp itself, so this needs nothing installed;
+# `timeout` is what bounds a filtered port, which otherwise hangs for the
+# kernel's full SYN retry.
+tcp_open() {
+    timeout 4 bash -c 'exec 3<>/dev/tcp/$1/$2' _ "$1" "$2" 2>/dev/null
+}
+
+# The banner is whatever the server volunteers before we say anything. Reading
+# it is not a login attempt and leaves no session behind.
+tcp_banner() {
+    timeout 5 bash -c '
+        exec 3<>/dev/tcp/$1/$2 || exit 1
+        IFS= read -r -t 3 line <&3
+        printf "%s" "$line"
+    ' _ "$1" "$2" 2>/dev/null | tr -d '\r'
+}
+
+# Same probe from the Windows side, for a port WSL's NAT cannot reach.
+win_tcp_open() {
+    local r
+    r=$(win_ps <<PSEOF
+\$c = New-Object System.Net.Sockets.TcpClient
+if (\$c.ConnectAsync('$1', $2).Wait(4000) -and \$c.Connected) { Write-Output 'open' }
+\$c.Close()
+PSEOF
+    )
+    [ "$r" = "open" ]
+}
+
+# --- pick the L2 view -----------------------------------------------------
+
+view=none
+if [ -x "$PS_EXE" ] && [ -x "$ARP_EXE" ]; then
+    # Interop can be installed and still not answer -- the WSL vsock relay drops
+    # out and every .exe then fails identically to one not being there.
+    # Presence of the file proves nothing; a table coming back does. The outage
+    # is usually seconds, and demoting a run to reachability-only over one
+    # dropped call throws away the only view that can name a board, so it is
+    # retried before being believed.
+    for attempt in 1 2 3; do
+        probe=$(timeout 30 "$ARP_EXE" -a 2>/dev/null | tr -d '\r')
+        if printf '%s' "$probe" | grep -q 'Interface:'; then
+            view=windows
+            break
+        fi
+        [ "$attempt" -lt 3 ] && sleep 5
+    done
+    [ "$view" = windows ] || \
+        echo "warning: Windows interop is present but not answering after 3 tries -- falling back" >&2
+fi
+if [ "$view" = none ]; then
+    # A /24 view exists iff some interface address shares the three octets.
+    if ip -4 -o addr show 2>/dev/null | awk '{print $4}' | cut -d/ -f1 \
+        | grep -qx "$PREFIX\.[0-9]*"; then
+        view=local
+    fi
+fi
+
+# Both start "yes" and only the windows path can clear them: the up-front probe
+# proves interop answered once, not that it will answer for the two calls that
+# carry the result.
+sweep_answered=yes
+table_answered=yes
+
+echo "sweeping $PREFIX.1-254 (L2 view: $view) ..."
+
+# --- sweep ----------------------------------------------------------------
+
+if [ "$view" = windows ]; then
+    # One asynchronous ping per address, all in flight at once: a serial sweep
+    # of 254 addresses at a one-second timeout is four minutes, and this is two.
+    replies=$(win_ps <<PSEOF
+\$t = foreach (\$i in 1..254) {
+    (New-Object System.Net.NetworkInformation.Ping).SendPingAsync('$PREFIX.' + \$i, 1000)
+}
+[System.Threading.Tasks.Task]::WaitAll(\$t)
+Write-Output (@(\$t | Where-Object { \$_.Result.Status -eq 'Success' }).Count)
+PSEOF
+    )
+    case "$replies" in
+        ''|*[!0-9]*)
+            sweep_answered=no
+            echo "warning: the Windows sweep did not report a count -- interop may have dropped mid-run" >&2 ;;
+        *) echo "  $replies of 254 answered" ;;
+    esac
+else
+    # Every ping in flight at once, and each one that answers appends its own
+    # address: 254 sequential probes at a one-second timeout is four minutes,
+    # which is long enough that the sweep reads as a hang.
+    RESPONDERS=$(mktemp)
+    trap 'rm -f "$RESPONDERS"' EXIT
+    for i in $(seq 1 254); do
+        ( ping -c1 -W1 "$PREFIX.$i" > /dev/null 2>&1 && echo "$PREFIX.$i" >> "$RESPONDERS" ) &
+    done
+    wait
+    echo "  $(wc -l < "$RESPONDERS") of 254 answered"
+fi
+
+# --- read the neighbour table --------------------------------------------
+
+# Normalised to "<ip> <mac>", MACs lower-case and colon-separated whatever the
+# source spelled them. Matching an OUI against the whole line instead would let
+# an interface header or a hostname satisfy the pattern.
+case "$view" in
+    windows)
+        # A table that arrived carries the interface header, whether or not it
+        # holds a single entry. Nothing at all means the call failed, and an
+        # empty table and a failed call are the same string once awk has run --
+        # so the distinction is made here, on the raw output, while it exists.
+        raw=$(timeout 30 "$ARP_EXE" -a 2>/dev/null | tr -d '\r')
+        case "$raw" in *Interface:*) ;; *) table_answered=no ;; esac
+        table=$(printf '%s\n' "$raw" \
+            | awk '$1 ~ /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/ && $2 ~ /^[0-9a-fA-F-]{17}$/ {print $1, $2}')
+        source_desc="Windows ARP cache ($ARP_EXE -a)"
+        ;;
+    local)
+        if command -v ip > /dev/null; then
+            table=$(ip neigh show 2>/dev/null \
+                | awk '{for (i=1;i<NF;i++) if ($i=="lladdr") print $1, $(i+1)}')
+            source_desc="ip neigh"
+        elif command -v arp > /dev/null; then
+            table=$(arp -an 2>/dev/null \
+                | awk '{ip=$2; gsub(/[()]/,"",ip); for (i=1;i<NF;i++) if ($i=="at") print ip, $(i+1)}')
+            source_desc="arp -an"
+        else
+            echo "an interface is inside $CIDR but neither ip nor arp is installed" >&2
+            exit 2
+        fi
+        ;;
+    none)
+        table=""
+        source_desc="none"
+        ;;
+esac
+
+table=$(printf '%s\n' "$table" | tr 'A-F' 'a-f' | tr '-' ':' \
+    | grep -E "^$PREFIX\.[0-9]+ ([0-9a-f]{2}:){5}[0-9a-f]{2}$" \
+    | grep -v ' ff:ff:ff:ff:ff:ff$' | sort -t. -k4 -n -u)
+
+# --- report ---------------------------------------------------------------
+
+# Interop can pass the up-front probe and then die during the run, and the two
+# calls that carry the whole result are the sweep and the table read. When the
+# table read returned nothing, or the sweep reported no count AND not one
+# in-range neighbour came back, "nothing answered ARP" would be an affirmative
+# claim about the LAN drawn from calls that never ran. A dead relay explains
+# that shape far better than an empty subnet, and it is the shape a live run
+# produced with the board sitting on the LAN the whole time. So it degrades to
+# the same "no L2 view" verdict as having no interop at all.
+if [ "$view" = windows ] && { [ "$table_answered" = no ] || \
+    { [ "$sweep_answered" = no ] && [ -z "$table" ]; }; }; then
+    if [ "$table_answered" = no ]; then
+        why="the neighbour-table read returned nothing at all -- not an empty table, no table"
+    else
+        why="the sweep reported no count and the neighbour table came back with nothing in range"
+    fi
+    echo
+    echo "the Windows interop this run depends on answered the opening probe and"
+    echo "then stopped: $why."
+    echo
+    echo "This host is WSL, so those calls ARE the L2 view of $CIDR -- WSL2 sits"
+    echo "behind NAT and its own neighbour table never holds a LAN peer. Nothing"
+    echo "was measured. This is NOT evidence that $CIDR is empty, and a device"
+    echo "sitting there right now would produce exactly this output."
+    echo
+    echo "the outage is usually seconds -- run it again, or run it from a host"
+    echo "on that LAN."
+    exit 3
+fi
+
+if [ "$view" = none ]; then
+    echo
+    echo "this host has no L2 view of $CIDR: no interface is inside it and no"
+    echo "working Windows interop, so nothing here ever sees a MAC from that"
+    echo "subnet. Reachability is all that can be measured, and it can only say"
+    echo "which addresses answered -- not which of them is a Pi, and not that a"
+    echo "silent address is unused."
+    echo
+    echo "addresses in $CIDR that answered:"
+    if [ -s "$RESPONDERS" ]; then
+        sort -t. -k4 -n -u "$RESPONDERS" | while read -r ip; do
+            printf '  %-15s' "$ip"
+            if tcp_open "$ip" 22; then
+                printf ' tcp/22 open  %s' "$(tcp_banner "$ip" 22)"
+            else
+                printf ' tcp/22 no answer'
+            fi
+            printf '\n'
+        done
+    else
+        echo "  (none -- and a host that drops ICMP answers nothing here either)"
+    fi
+    echo
+    echo "run this from a host on that LAN to identify anything."
+    exit 3
+fi
+
+pattern=$(printf '%s' "$OUIS" | tr ' ' '\n' | sed 's/^/ /' | paste -sd'|' -)
+hits=$(printf '%s\n' "$table" | grep -E "$pattern") || true
 
 if [ -z "$hits" ]; then
-    echo "no Raspberry Pi OUI in the ARP cache for $PREFIX.0/24"
-    echo "the full cache follows -- a newer board may carry an OUI this list predates"
-    arp -a
+    echo
+    echo "no Raspberry Pi OUI in $source_desc for $CIDR"
+    if [ -z "$table" ]; then
+        echo "  $source_desc holds no entry in that range at all -- nothing answered ARP"
+    else
+        echo "the whole table follows -- a newer board may carry an OUI this list predates"
+        printf '%s\n' "$table" | sed 's/^/  /'
+    fi
     exit 1
 fi
-printf '%s\n' "$hits"
+
+echo
+echo "Raspberry Pi OUIs in $source_desc:"
+printf '%s\n' "$hits" | while read -r ip mac; do
+    printf '  %-15s %s' "$ip" "$mac"
+    if tcp_open "$ip" 22; then
+        printf '  tcp/22 open  %s' "$(tcp_banner "$ip" 22)"
+    elif [ "$view" = windows ] && win_tcp_open "$ip" 22; then
+        # Reachable from Windows but not from here: WSL's NAT is in the way, not
+        # the device. Saying "closed" would blame the wrong host.
+        printf '  tcp/22 open from Windows, not routable from WSL'
+    else
+        printf '  tcp/22 no answer'
+    fi
+    printf '\n'
+done
+echo
+echo "an OUI says a Raspberry Pi, not which one -- confirm by logging in."

--- a/tools/kiosk-screenshot.sh
+++ b/tools/kiosk-screenshot.sh
@@ -3,6 +3,10 @@
 #
 #   tools/kiosk-screenshot.sh root@<host> [out.png]
 #
+# The capture itself needs a reachable kiosk. What runs without one: argument
+# handling, the overwrite guard, mkdir of the output directory, and the
+# ssh/scp failure modes against an unreachable or nonexistent host.
+#
 # `import -window root` (imagemagick) is the capture path this image carries.
 # There is no scrot and no fbgrab: fbgrab was dropped on a misdiagnosis and
 # never restored -- see docs/issue_investigation/screenshot_capture_fbgrab/README.md

--- a/tools/kiosk-tcp-state.sh
+++ b/tools/kiosk-tcp-state.sh
@@ -3,9 +3,9 @@
 #
 #   tools/kiosk-tcp-state.sh <kiosk-address> [port]
 #
-# Run this ON THE MACHINE SERVING THE PAGE. netstat only sees sockets local to
-# the host it runs on, so pointing it at the kiosk from a third machine reports
-# nothing and reads exactly like a kiosk that is not connecting.
+# Run this ON THE MACHINE SERVING THE PAGE. A socket table only holds sockets
+# local to the host it is read on, so pointing this at the kiosk from a third
+# machine reports nothing and reads exactly like a kiosk that is not connecting.
 #
 # This is the read of last resort: the kiosk's correct display is a black
 # background, so "working", "browser crashed", "JavaScript threw" and "X never
@@ -32,14 +32,48 @@ set -uo pipefail
 ADDR=${1:?usage: kiosk-tcp-state.sh <kiosk-address> [port]}
 PORT=${2:-8080}
 
-command -v netstat > /dev/null || { echo "netstat not installed on this host" >&2; exit 2; }
+# ss is iproute2 and present wherever `ip` is; netstat is net-tools, which many
+# images no longer ship at all. Their state names differ -- ss says ESTAB and
+# FIN-WAIT-2, netstat says ESTABLISHED and FIN_WAIT2 -- so whichever ran, the
+# names are canonicalised below to the spelling the table above uses, which is
+# neither engine's. A table whose rows can never match the output is worse than
+# no table.
+if command -v ss > /dev/null; then
+    engine="ss"
+    rows=$(ss -tan 2>/dev/null)
+    statecol=1
+elif command -v netstat > /dev/null; then
+    engine="netstat"
+    rows=$(netstat -an 2>/dev/null | grep '^tcp')
+    statecol=6
+else
+    echo "neither ss (iproute2) nor netstat (net-tools) is installed on this host" >&2
+    exit 2
+fi
 
-# The state is the last field of a netstat TCP row. Counting local addresses
-# instead answers a different question and produces a table that never matches
-# the one above.
-out=$(netstat -an | grep "^tcp" | grep "$ADDR" | grep ":$PORT" | awk '{print $NF}' | sort | uniq -c)
+# The kiosk is the CLIENT here: this host listens on PORT and the kiosk dials in
+# from an ephemeral port. So the rows that belong to it are the ones whose local
+# port is PORT and whose peer address is the kiosk -- both columns, not either.
+# Matching the address anywhere in the row also catches this host's own outbound
+# connections to the kiosk and the listening socket, which answers a different
+# question and produces a count that never matches the table above.
+#
+# Column 4 is the local address and column 5 the peer in both engines; only the
+# state moves, which is what statecol carries.
+out=$(printf '%s\n' "$rows" | awk -v sc="$statecol" -v addr="$ADDR" -v port="$PORT" '
+    $1 == "State" { next }
+    NF >= 5 {
+        lp = $4; sub(/.*:/, "", lp)
+        pa = $5; sub(/:[^:]*$/, "", pa); gsub(/[][]/, "", pa)
+        if (lp == port && pa == addr) print $sc
+    }' \
+    | sed -e 's/-/_/g' \
+          -e 's/^ESTAB$/ESTABLISHED/' \
+          -e 's/^FIN_WAIT\([12]\)$/FIN_WAIT_\1/' \
+          -e 's/^SYN_RECV$/SYN_RECEIVED/' \
+    | sort | uniq -c)
 
-echo "$ADDR:$PORT  $(date '+%H:%M:%S')"
+echo "$ADDR:$PORT  $(date '+%H:%M:%S')  [$engine]"
 if [ -z "$out" ]; then
     echo "  no connections"
 else

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -33,8 +33,9 @@ SSID=$(val WIFI_SSID);      PSK=$(val WIFI_PSK_HASH)
 URL=$(val KIOSK_URL);       HOST=$(val KIOSK_HOSTNAME)
 NS=$(val KIOSK_NAMESERVER); MID=$(val KIOSK_MACHINE_ID)
 
-for n in SSID PSK URL HOST NS; do
-    [ -n "${!n}" ] || { echo "secrets.yaml is missing $n"; exit 1; }
+for pair in SSID:WIFI_SSID PSK:WIFI_PSK_HASH URL:KIOSK_URL HOST:KIOSK_HOSTNAME NS:KIOSK_NAMESERVER; do
+    n=${pair%%:*}; real=${pair#*:}
+    [ -n "${!n}" ] || { echo "secrets.yaml is missing $real"; exit 1; }
 done
 
 # machine-id: 32 lowercase hex. Generated per device if secrets.yaml has none --
@@ -122,9 +123,19 @@ case "$MODE" in
     # transfer shape is not a consideration here either way.
     # --owner/--group: tar otherwise preserves THIS host's uid/gid, landing the
     # wifi credentials owned by uid 1000 on the device.
+    #
+    # rc is captured rather than left to errexit: a bare ssh diagnostic and a
+    # silent exit 255 say nothing about which of this script's two remote steps
+    # ran, and the difference matters -- a write that failed leaves /data as it
+    # was, a read-back that failed does not say whether the write landed.
+    rc=0
     tar -C "$STAGE" --owner=root --group=root --numeric-owner -cf - . | ssh "${ssh_opts[@]}" "$DEST" \
-        'mkdir -p /data/config /data/etc && tar -C /data -xf - && chown -R 0:0 /data/config /data/etc && chmod 0600 /data/config/wpa_supplicant.conf && sync'
-    ssh "${ssh_opts[@]}" "$DEST" 'ls -l /data/config /data/etc/machine-id'
+        'mkdir -p /data/config /data/etc && tar -C /data -xf - && chown -R 0:0 /data/config /data/etc && chmod 0600 /data/config/wpa_supplicant.conf && sync' || rc=$?
+    [ "$rc" -eq 0 ] || { echo "could not write /data on $DEST (tar|ssh rc=$rc) -- nothing was provisioned" >&2; exit 1; }
+
+    rc=0
+    ssh "${ssh_opts[@]}" "$DEST" 'ls -l /data/config /data/etc/machine-id' || rc=$?
+    [ "$rc" -eq 0 ] || { echo "wrote /data on $DEST but could not read it back (ssh rc=$rc) -- check it by hand" >&2; exit 1; }
     echo "provisioned $DEST"
     ;;
   *) echo "unknown mode $MODE"; exit 1 ;;

--- a/tools/send-bundle-chunked.sh
+++ b/tools/send-bundle-chunked.sh
@@ -6,6 +6,11 @@
 # meta-wisekiosk/recipes-core/kiosk-cpufreq. Kept until removal lands --
 # issue #29 remove chunked bundle delivery.
 #
+# The transfer loop needs a reachable kiosk end to end. What runs without
+# one: argument handling, the BUNDLE readability check, and the bounded
+# retry/timeout behavior of wait_for_device against an unreachable or
+# nonexistent host.
+#
 # Evidence this was built on, measured on the uncapped board
 # (mechanism: docs/issue_investigation/wifi_instability/README.md):
 #   Test A  334 MB written to /data + sync, negligible network  -> SURVIVED
@@ -26,7 +31,11 @@
 # honest progress marker.
 set -u
 
-BUNDLE=$(readlink -f "${1:?usage: send-bundle-chunked.sh <file> [chunk_mb] [rx_pause] [sync_pause]}")
+# The usage check has to fire BEFORE the command substitution, not inside it:
+# `${1:?}` there kills only the subshell, and the parent carries on with an
+# empty BUNDLE to fail a second time on the readability check below.
+[ $# -ge 1 ] || { echo "usage: send-bundle-chunked.sh <file> [chunk_mb] [rx_pause] [sync_pause]" >&2; exit 1; }
+BUNDLE=$(readlink -f "$1")
 CHUNK_MB=${2:-2}
 RX_PAUSE=${3:-4}
 SYNC_PAUSE=${4:-3}
@@ -34,7 +43,12 @@ HOST=${KIOSK_HOST:-root@192.168.1.6}
 DEST=${KIOSK_DEST:-/data/update.raucb}
 SSH="ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
 
-SIZE=$(stat -Lc%s "$BUNDLE")          # -L: a symlink's own size is its target's NAME length
+# Checked here, not left to surface inside the transfer loop: an unreadable
+# BUNDLE would otherwise leave SIZE empty and fall straight into
+# wait_for_device, which retries the device for up to 400s before anything
+# says the real problem was a missing local file.
+[ -r "$BUNDLE" ] || { echo "no such file: $BUNDLE" >&2; exit 1; }
+SIZE=$(stat -Lc%s "$BUNDLE") || { echo "cannot stat $BUNDLE" >&2; exit 1; }  # -L: a symlink's own size is its target's NAME length
 CHUNK=$((CHUNK_MB * 1024 * 1024))
 LOCAL_MD5=$(md5sum "$BUNDLE" | cut -d' ' -f1)
 MAX_STALL=${MAX_STALL:-40}            # consecutive no-progress rounds before giving up


### PR DESCRIPTION
Applies the owner's rule (2026-08-14): **a script may claim to work only if it has been executed end-to-end in the environment it serves.** The `just find` family shipped in PR #30 green through syntax checks, seeded unit tests and code review — and was not remotely functional on the real host. This PR is the result of actually running everything.

## Verified by execution
- **Discovery works and found the board.** `kiosk-find.sh` rebuilt around three explicit L2 views — Windows-interop ARP (WSL2 NAT has no L2 adjacency to the LAN), `ip neigh` natively, loud reachability-only fallback — each named in the output, with a mid-run interop failure degrading to "no L2 view" instead of a confident false "nothing answered". Verified against the live LAN; an independent re-runner corroborated the found board three ways without the script.
- **The flash path lied about success.** `just flash` printed "Done. Safe to eject" while `sudo dd` had failed (script recipe had no errexit), and never re-read the partition table — so `provision-fresh-card` seconds later saw an unflashed card. Both fixed, proven against the seeded original failure, then verified with a real 16G flash (5.1 GB written, 4-partition layout byte-identical to the image's sfdisk map) and a first-run-clean `provision-fresh-card`, with the provision checks (mode, ownership) each proven able to fail first. Not verified: that the card boots — that needs a board.
- **tcp-state** on `ss` with `netstat` fallback, parse chain proven by loopback self-tests with negative controls (including the substring-address trap).
- **Failure modes are loud and bounded**: every device script tested against an unreachable IP and a nonexistent hostname (ConnectTimeout-bound, distinguishable messages, no leftover artifacts); a missing local bundle now fails in 0.1 s instead of probing an offline device for 400 s.
- **`KIOSK_HOST` env now drives every default device address** — the HITL unit intentionally changes boards, so any literal default goes stale by design. Diagnostic outputs (backups, profiles, screenshots) default into gitignored `local/`.

## Honesty edits
Claims that cannot be verified without a reachable device (live capture, boot profile cycle, backup stream) now say so in place instead of asserting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URcEwcTUTS1yDHBRGZq5DS