### PR TITLE
image: drop inert iproute2-tc (#22 part b)

### DIFF
--- a/kiosk-zero-w.yaml
+++ b/kiosk-zero-w.yaml
@@ -80,14 +80,6 @@ local_conf_header:
     # a different kind of change, deliberately not batched with this one.
     PACKAGECONFIG:remove:pn-webkitgtk3 = "jit gtk4 enchant"
 
-    # iproute2-tc: ingress rate policing, so the board enforces its own receive
-    # ceiling instead of trusting every sender. The kernel modules (sch_ingress,
-    # act_police, sch_tbf, cls_u32) are already built in; only the binary was
-    # missing. This MUST live here, not in autonomos-common.inc -- the kas target
-    # is core-image-base, and that .inc is only included by autonomos-base.bb,
-    # which is not built. The first attempt went there and silently shipped nothing.
-    IMAGE_INSTALL:append = " iproute2-tc"
-
     # kiosk-cpufreq: caps scaling_max_freq below this board's unstable top OPP.
     # THE fix for the crash diagnosed 2026-08-13 -- 1000 MHz corrupts memory
     # under sustained SDIO + network load (2/2 deaths pinned there; 8/8


### PR DESCRIPTION
## What

Removes `iproute2-tc` from `kiosk-zero-w.yaml`'s `IMAGE_INSTALL` (the package plus its explanatory comment block).

## Why it's safe

`iproute2-tc` was meant to enforce an ingress rate ceiling, but the qdisc was never configured on the device. Verified inert on three independent grounds (triage `scope-img.md`):

1. **Nothing executes it** — `git grep -nE '\btc\b|qdisc|ingress|police'` over `meta-wisekiosk tools justfiles docs` returns zero hits: no unit, init script, udev rule, doc, or tool.
2. **It's a leaf** — a bare `IMAGE_INSTALL:append`, RDEPENDS'd by nothing in the image.
3. **No rebuild risk** — `IMAGE_INSTALL` is image-level, so this re-runs `do_rootfs` and re-hashes no recipe; it cannot reach the kernel, brcmfmac, or webkitgtk3.

No tracked Markdown references `tc`, so `just verify` / `doc-image.py` are unaffected. Payload removed: ~554 KB.

## Scope

Only part **(b)** of #22. Part (a) (`openssh-sftp-server`) is deliberately **not** done — `scp`/`sftp` share the package and `scp` is the OTA lifeline — so #22 stays open for that half.

Delivery: land now, ships on the next image built for any other reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)