### PR TITLE
kiosk-recover: /data recovery recipe that reverses the boot trims (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,30 +147,25 @@ multi-GB image to put back.
 
 ## Recovery
 
-`kiosk-hardware` trims the boot to the point of a display behind glass: no DNS resolver, no
-`logind`/`userdbd`, no Bluetooth input, masked udev rules. That is correct for the wall but hostile to
-a debugging session. `kiosk-recover` reverses those trims — it unmasks the resolver, login/session and
-userdb units, deletes the masked udev rule symlinks, re-enables Bluetooth, restores the
-`/etc/resolv.conf` symlink into `/data`, and reboots into an interactively-debuggable box.
+`kiosk-recover` reverses `kiosk-hardware`'s boot trims for a debugging session: it unmasks the DNS
+resolver, login/session and userdb units, deletes the masked udev rule symlinks, re-enables
+Bluetooth, restores the `/etc/resolv.conf` symlink into `/data`, and reboots.
 
-It is **not a boot un-bricker.** It runs on a slot that already boots far enough to give a shell; a
-slot that does not is an A/B rollback (`just kiosk-rollback`), not this. It is idempotent, touches
-neither `/boot`, `sshd`, networkd nor `wpa_supplicant`, and has no timer, deadman or auto-revert —
-this recovery machinery is itself untested, so it runs only when a human runs it. It deliberately
-leaves `zram.service` masked (issue #17: that mask is a defect workaround, not a boot trim).
+It is **not a boot un-bricker**: it runs on a slot that already gives a shell; a slot that does not is
+an A/B rollback (`just kiosk-rollback`). It is idempotent, touches neither `/boot`, `sshd`, networkd
+nor `wpa_supplicant`, has no timer/deadman/auto-revert, and leaves `zram.service` masked (issue #17:
+that mask is a defect workaround, not a trim).
 
-The script lives on **`/data`**, not the rootfs, so it survives an A/B flip and a reflash and is
-present regardless of which image booted. `tools/provision.sh` places it at `/data/RECOVER.sh`
-alongside the site config; its source of truth is the
-[`kiosk-recover`](meta-wisekiosk/recipes-core/kiosk-recover/) recipe. On the device:
+It lives on **`/data`** (placed at `/data/RECOVER.sh` by `tools/provision.sh`; source in the
+[`kiosk-recover`](meta-wisekiosk/recipes-core/kiosk-recover/) recipe), so it survives an A/B flip and
+a reflash. On the device:
 
 ```sh
-/data/RECOVER.sh --dry-run   # print exactly what would change; touch nothing; no reboot
+/data/RECOVER.sh --dry-run   # list exactly what would change; touch nothing
 /data/RECOVER.sh             # apply and reboot
 ```
 
-Always `--dry-run` first: it lists the exact unit masks, udev symlinks and modprobe lines it would
-touch, so targeting is confirmed before anything changes.
+Run `--dry-run` first to confirm targeting.
 
 ## Upstream fixes
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,33 @@ Losing `/data` is a re-provisioning, not a restore. `tools/provision.sh` writes 
 again from `secrets.yaml`, and a machine-id not recorded there comes back as a new one; there is no
 multi-GB image to put back.
 
+## Recovery
+
+`kiosk-hardware` trims the boot to the point of a display behind glass: no DNS resolver, no
+`logind`/`userdbd`, no Bluetooth input, masked udev rules. That is correct for the wall but hostile to
+a debugging session. `kiosk-recover` reverses those trims — it unmasks the resolver, login/session and
+userdb units, deletes the masked udev rule symlinks, re-enables Bluetooth, restores the
+`/etc/resolv.conf` symlink into `/data`, and reboots into an interactively-debuggable box.
+
+It is **not a boot un-bricker.** It runs on a slot that already boots far enough to give a shell; a
+slot that does not is an A/B rollback (`just kiosk-rollback`), not this. It is idempotent, touches
+neither `/boot`, `sshd`, networkd nor `wpa_supplicant`, and has no timer, deadman or auto-revert —
+this recovery machinery is itself untested, so it runs only when a human runs it. It deliberately
+leaves `zram.service` masked (issue #17: that mask is a defect workaround, not a boot trim).
+
+The script lives on **`/data`**, not the rootfs, so it survives an A/B flip and a reflash and is
+present regardless of which image booted. `tools/provision.sh` places it at `/data/RECOVER.sh`
+alongside the site config; its source of truth is the
+[`kiosk-recover`](meta-wisekiosk/recipes-core/kiosk-recover/) recipe. On the device:
+
+```sh
+/data/RECOVER.sh --dry-run   # print exactly what would change; touch nothing; no reboot
+/data/RECOVER.sh             # apply and reboot
+```
+
+Always `--dry-run` first: it lists the exact unit masks, udev symlinks and modprobe lines it would
+touch, so targeting is confirmed before anything changes.
+
 ## Upstream fixes
 
 Two changes to upstream cannot be expressed from a downstream layer and live as patches in

--- a/meta-wisekiosk/recipes-core/kiosk-recover/files/kiosk-recover
+++ b/meta-wisekiosk/recipes-core/kiosk-recover/files/kiosk-recover
@@ -1,31 +1,11 @@
 #!/bin/sh
-# kiosk-recover -- reverse kiosk-hardware's boot trims so the locked-down kiosk
-# becomes an interactively-debuggable Linux box again, then reboot.
+# kiosk-recover -- reverse kiosk-hardware's boot trims for a debugging session,
+# then reboot. Not a boot un-bricker: it runs on a slot that already gives a
+# shell; a dead slot is an A/B rollback. Idempotent. Touches neither /boot, sshd,
+# networkd nor wpa_supplicant. No timer/deadman/auto-revert -- runs only by hand.
+# Lives on /data (tools/provision.sh), so it survives an A/B flip and a reflash.
 #
-# It restores, in order:
-#   1. the DNS resolver, login/session and userdb units kiosk-hardware masks
-#   2. default udev device handling (the masked rule files)
-#   3. Bluetooth input (the modprobe drop-in's third pass)
-#   4. the /etc/resolv.conf symlink into /data
-#   5. reboot
-#
-# This is NOT a boot un-bricker. It runs on a slot that already boots far enough
-# to give a shell; it cannot rescue a slot that does not. Recovery of a dead
-# slot is an A/B rollback, not this.
-#
-# Idempotent -- safe to run twice; a second run finds nothing left to do.
-# It does NOT touch /boot, sshd, systemd-networkd or wpa_supplicant, and there
-# is deliberately NO timer, deadman or auto-revert: this recovery machinery is
-# itself an untested change, so it only ever runs when a human runs it.
-#
-# Placement: this script lives on /data (see tools/provision.sh), which survives
-# an A/B flip and a reflash, so it is present regardless of which image booted.
-#
-# Usage:
-#   kiosk-recover            apply the changes and reboot
-#   kiosk-recover --dry-run  print exactly what would change; touch nothing; no
-#                            reboot. Use this to confirm targeting before the
-#                            real run.
+# Usage: kiosk-recover [--dry-run]   # --dry-run prints changes, touches nothing
 
 set -u
 
@@ -40,15 +20,10 @@ log()  { echo "kiosk-recover: $*"; }
 act()  { if [ "$DRY" -eq 1 ]; then echo "  would: $*"; else "$@"; fi; }
 
 # --- 1. unmask the boot-trim units ----------------------------------------
-# kiosk-hardware masks these with /dev/null symlinks in /etc/systemd/system.
-# Remove ONLY a mask (a symlink to /dev/null), never a real unit or drop-in a
-# human may have added there.
-#
-# zram.service is DELIBERATELY NOT in this list. Its mask is not a boot trim --
-# it is a defect workaround (issue #17): the unit fails every boot with "Device
-# or resource busy" and, when it does run, sizes swap at 90% of RAM. Unmasking
-# it restores a broken unit, so recovery leaves it masked on purpose. Do not
-# "fix" this omission by adding zram.service here.
+# Remove only a mask (a symlink -> /dev/null), never a real unit. zram.service is
+# excluded on purpose: its mask is a defect workaround (issue #17), not a boot
+# trim -- unmasking restores a unit that fails every boot and sizes swap at 90%
+# of RAM. Do not add it here.
 for u in systemd-resolved.service systemd-logind.service \
          systemd-userdbd.service systemd-userdbd.socket; do
     p="/etc/systemd/system/$u"
@@ -61,15 +36,9 @@ for u in systemd-resolved.service systemd-logind.service \
 done
 
 # --- 2. delete the udev rule masks ----------------------------------------
-# kiosk-hardware masks rules by installing /dev/null symlinks in
-# /etc/udev/rules.d (KIOSK_UDEV_RULES_MASKED). Remove SYMLINKS ONLY.
-#
-# The '-type l' restriction is load-bearing, not a nicety: FILES:${PN} claims
-# the whole /etc/udev/rules.d directory, so any real *.rules file there is a
-# shipped file. The first version of this script glob-deleted *.rules and
-# destroyed three shipped files (99-fuse, can, touchscreen). NEVER widen this to
-# a *.rules glob. The extra "-> /dev/null" check keeps it to kiosk-hardware's
-# own masks and spares any other symlink someone may have placed here.
+# Symlinks to /dev/null only. -type l is load-bearing: /etc/udev/rules.d is
+# FILES:${PN}, so a real *.rules file there is a shipped file -- never widen to a
+# *.rules glob. The -> /dev/null check spares any non-mask symlink placed here.
 if [ -d /etc/udev/rules.d ]; then
     find /etc/udev/rules.d -maxdepth 1 -type l | while IFS= read -r l; do
         [ "$(readlink "$l")" = /dev/null ] || continue
@@ -78,14 +47,11 @@ if [ -d /etc/udev/rules.d ]; then
     done
 fi
 
-# --- 3. re-enable Bluetooth (the modprobe third pass) ---------------------
-# There is no separate Bluetooth drop-in. Bluetooth is the third pass of the
-# single combined /etc/modprobe.d/kiosk-blacklist.conf. Comment out ONLY those
-# six lines (install/blacklist for hci_uart, btbcm, bluetooth). Pass 1
-# (camera/ISP/codec/audio) and pass 2 (vc_sm_cma/gpiomem/uio) MUST survive
-# intact, so this matches those three exact module tokens and nothing else.
-# NEVER delete the file. Idempotent: an already-commented line no longer
-# matches, so a second run is a no-op.
+# --- 3. re-enable Bluetooth ------------------------------------------------
+# Bluetooth is the third pass of the combined kiosk-blacklist.conf, not a
+# separate file. Comment only the six install/blacklist lines for
+# hci_uart/btbcm/bluetooth; pass 1 (camera/codec) and pass 2 (vc_sm_cma) must
+# survive, so match those three tokens exactly. Never delete the file.
 BL=/etc/modprobe.d/kiosk-blacklist.conf
 if [ -f "$BL" ]; then
     hits=$(awk '
@@ -115,9 +81,8 @@ if [ -f "$BL" ]; then
 fi
 
 # --- 4. restore the resolv.conf symlink -----------------------------------
-# /etc/resolv.conf -> /data/config/resolv.conf (kiosk-static-resolv.bbclass).
-# The tmpfiles entry that ships this uses 'L', not 'L+', so it will NOT recreate
-# the symlink once /etc/resolv.conf exists -- whatever this writes is what stays.
+# Its tmpfiles entry uses 'L', not 'L+', so it will not recreate the symlink once
+# /etc/resolv.conf exists -- what this writes is what stays.
 WANT=/data/config/resolv.conf
 CUR=$(readlink /etc/resolv.conf 2>/dev/null || true)
 if [ "$CUR" = "$WANT" ]; then

--- a/meta-wisekiosk/recipes-core/kiosk-recover/files/kiosk-recover
+++ b/meta-wisekiosk/recipes-core/kiosk-recover/files/kiosk-recover
@@ -1,0 +1,137 @@
+#!/bin/sh
+# kiosk-recover -- reverse kiosk-hardware's boot trims so the locked-down kiosk
+# becomes an interactively-debuggable Linux box again, then reboot.
+#
+# It restores, in order:
+#   1. the DNS resolver, login/session and userdb units kiosk-hardware masks
+#   2. default udev device handling (the masked rule files)
+#   3. Bluetooth input (the modprobe drop-in's third pass)
+#   4. the /etc/resolv.conf symlink into /data
+#   5. reboot
+#
+# This is NOT a boot un-bricker. It runs on a slot that already boots far enough
+# to give a shell; it cannot rescue a slot that does not. Recovery of a dead
+# slot is an A/B rollback, not this.
+#
+# Idempotent -- safe to run twice; a second run finds nothing left to do.
+# It does NOT touch /boot, sshd, systemd-networkd or wpa_supplicant, and there
+# is deliberately NO timer, deadman or auto-revert: this recovery machinery is
+# itself an untested change, so it only ever runs when a human runs it.
+#
+# Placement: this script lives on /data (see tools/provision.sh), which survives
+# an A/B flip and a reflash, so it is present regardless of which image booted.
+#
+# Usage:
+#   kiosk-recover            apply the changes and reboot
+#   kiosk-recover --dry-run  print exactly what would change; touch nothing; no
+#                            reboot. Use this to confirm targeting before the
+#                            real run.
+
+set -u
+
+DRY=0
+case "${1:-}" in
+    --dry-run) DRY=1 ;;
+    "")        ;;
+    *) echo "usage: kiosk-recover [--dry-run]" >&2; exit 2 ;;
+esac
+
+log()  { echo "kiosk-recover: $*"; }
+act()  { if [ "$DRY" -eq 1 ]; then echo "  would: $*"; else "$@"; fi; }
+
+# --- 1. unmask the boot-trim units ----------------------------------------
+# kiosk-hardware masks these with /dev/null symlinks in /etc/systemd/system.
+# Remove ONLY a mask (a symlink to /dev/null), never a real unit or drop-in a
+# human may have added there.
+#
+# zram.service is DELIBERATELY NOT in this list. Its mask is not a boot trim --
+# it is a defect workaround (issue #17): the unit fails every boot with "Device
+# or resource busy" and, when it does run, sizes swap at 90% of RAM. Unmasking
+# it restores a broken unit, so recovery leaves it masked on purpose. Do not
+# "fix" this omission by adding zram.service here.
+for u in systemd-resolved.service systemd-logind.service \
+         systemd-userdbd.service systemd-userdbd.socket; do
+    p="/etc/systemd/system/$u"
+    if [ -L "$p" ] && [ "$(readlink "$p")" = /dev/null ]; then
+        act rm -f "$p"
+        log "unmasked $u"
+    else
+        log "already unmasked $u"
+    fi
+done
+
+# --- 2. delete the udev rule masks ----------------------------------------
+# kiosk-hardware masks rules by installing /dev/null symlinks in
+# /etc/udev/rules.d (KIOSK_UDEV_RULES_MASKED). Remove SYMLINKS ONLY.
+#
+# The '-type l' restriction is load-bearing, not a nicety: FILES:${PN} claims
+# the whole /etc/udev/rules.d directory, so any real *.rules file there is a
+# shipped file. The first version of this script glob-deleted *.rules and
+# destroyed three shipped files (99-fuse, can, touchscreen). NEVER widen this to
+# a *.rules glob. The extra "-> /dev/null" check keeps it to kiosk-hardware's
+# own masks and spares any other symlink someone may have placed here.
+if [ -d /etc/udev/rules.d ]; then
+    find /etc/udev/rules.d -maxdepth 1 -type l | while IFS= read -r l; do
+        [ "$(readlink "$l")" = /dev/null ] || continue
+        act rm -f "$l"
+        log "removed udev mask $(basename "$l")"
+    done
+fi
+
+# --- 3. re-enable Bluetooth (the modprobe third pass) ---------------------
+# There is no separate Bluetooth drop-in. Bluetooth is the third pass of the
+# single combined /etc/modprobe.d/kiosk-blacklist.conf. Comment out ONLY those
+# six lines (install/blacklist for hci_uart, btbcm, bluetooth). Pass 1
+# (camera/ISP/codec/audio) and pass 2 (vc_sm_cma/gpiomem/uio) MUST survive
+# intact, so this matches those three exact module tokens and nothing else.
+# NEVER delete the file. Idempotent: an already-commented line no longer
+# matches, so a second run is a no-op.
+BL=/etc/modprobe.d/kiosk-blacklist.conf
+if [ -f "$BL" ]; then
+    hits=$(awk '
+        /^[[:space:]]*#/ { next }
+        /^[[:space:]]*(install|blacklist)[[:space:]]+(hci_uart|btbcm|bluetooth)([[:space:]]|$)/ { print }
+    ' "$BL")
+    if [ -n "$hits" ]; then
+        if [ "$DRY" -eq 1 ]; then
+            echo "  would comment out these Bluetooth lines in $BL:"
+            printf '%s\n' "$hits" | sed 's/^/      /'
+        else
+            # cat over the original path (not mv) preserves its mode and owner.
+            awk '
+                /^[[:space:]]*#/ { print; next }
+                /^[[:space:]]*(install|blacklist)[[:space:]]+(hci_uart|btbcm|bluetooth)([[:space:]]|$)/ {
+                    print "# kiosk-recover disabled: " $0; next
+                }
+                { print }
+            ' "$BL" > "$BL.kiosk-recover.tmp" \
+                && cat "$BL.kiosk-recover.tmp" > "$BL" \
+                && rm -f "$BL.kiosk-recover.tmp"
+            log "re-enabled Bluetooth (commented 6 lines in $BL)"
+        fi
+    else
+        log "Bluetooth already re-enabled in $BL"
+    fi
+fi
+
+# --- 4. restore the resolv.conf symlink -----------------------------------
+# /etc/resolv.conf -> /data/config/resolv.conf (kiosk-static-resolv.bbclass).
+# The tmpfiles entry that ships this uses 'L', not 'L+', so it will NOT recreate
+# the symlink once /etc/resolv.conf exists -- whatever this writes is what stays.
+WANT=/data/config/resolv.conf
+CUR=$(readlink /etc/resolv.conf 2>/dev/null || true)
+if [ "$CUR" = "$WANT" ]; then
+    log "resolv.conf already -> $WANT"
+else
+    act rm -f /etc/resolv.conf
+    act ln -s "$WANT" /etc/resolv.conf
+    log "resolv.conf -> $WANT"
+fi
+
+# --- 5. reboot ------------------------------------------------------------
+if [ "$DRY" -eq 1 ]; then
+    log "dry-run: no changes made, not rebooting"
+    exit 0
+fi
+log "rebooting"
+reboot

--- a/meta-wisekiosk/recipes-core/kiosk-recover/kiosk-recover_1.0.bb
+++ b/meta-wisekiosk/recipes-core/kiosk-recover/kiosk-recover_1.0.bb
@@ -1,29 +1,18 @@
-SUMMARY = "Recovery script that reverses kiosk-hardware's boot trims -- placed on /data, not the rootfs"
-DESCRIPTION = "kiosk-recover turns the locked-down kiosk back into an interactively-debuggable Linux \
-box: it unmasks the DNS resolver, login/session and userdb units kiosk-hardware masks, deletes the \
-masked udev rule symlinks, re-enables Bluetooth input, restores the /etc/resolv.conf symlink into \
-/data, and reboots. It is NOT a boot un-bricker -- it runs on a slot that already reaches a shell. \
-\
-It runs only when a human runs it: no timer, no deadman, no auto-revert, because this recovery \
-machinery is itself an untested change. It does not touch /boot, sshd, networkd or wpa_supplicant, \
-and it deliberately leaves zram.service masked (issue #17: unmasking restores a unit that fails \
-every boot and sizes swap at 90% of RAM). \
-\
-This recipe is the tree home and single source of truth for the script. It is DELIBERATELY installed \
-into no image: the script is placed on /data by tools/provision.sh, because /data survives an A/B \
-flip and a reflash and is present regardless of which image version booted -- a per-slot rootfs \
-install is not. Because it ships no service and is in no IMAGE_INSTALL, ci-guards.sh guard 7 (auto- \
-enabled service reachability) cannot see it; guard 8 checks the /data placement path instead."
+SUMMARY = "Recovery script that reverses kiosk-hardware's boot trims; placed on /data by provisioning"
+DESCRIPTION = "kiosk-recover unmasks the resolver, login/session and userdb units, deletes the masked \
+udev symlinks, re-enables Bluetooth, restores the /etc/resolv.conf symlink, and reboots -- turning \
+the locked-down kiosk back into a debuggable box. Not a boot un-bricker. Placed on /data by \
+tools/provision.sh, not installed into any image (see do_install)."
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 SRC_URI = "file://kiosk-recover"
 S = "${WORKDIR}"
 
-# No do_install and no IMAGE_INSTALL on purpose (see DESCRIPTION): delivery is
-# tools/provision.sh -> /data/RECOVER.sh, not a rootfs package. This recipe
-# exists so the script has a versioned home under the layer and is linted by
-# ci-guards.sh guard 3 like every other shipped script.
+# No do_install / no IMAGE_INSTALL on purpose: delivery is tools/provision.sh ->
+# /data/RECOVER.sh (survives an A/B flip and reflash), not a rootfs package.
+# Ships no service, so guard 7 can't police it; guard 8 checks the /data path.
+# The recipe gives the script a versioned home and guard-3 lint.
 do_install() {
     :
 }

--- a/meta-wisekiosk/recipes-core/kiosk-recover/kiosk-recover_1.0.bb
+++ b/meta-wisekiosk/recipes-core/kiosk-recover/kiosk-recover_1.0.bb
@@ -1,0 +1,29 @@
+SUMMARY = "Recovery script that reverses kiosk-hardware's boot trims -- placed on /data, not the rootfs"
+DESCRIPTION = "kiosk-recover turns the locked-down kiosk back into an interactively-debuggable Linux \
+box: it unmasks the DNS resolver, login/session and userdb units kiosk-hardware masks, deletes the \
+masked udev rule symlinks, re-enables Bluetooth input, restores the /etc/resolv.conf symlink into \
+/data, and reboots. It is NOT a boot un-bricker -- it runs on a slot that already reaches a shell. \
+\
+It runs only when a human runs it: no timer, no deadman, no auto-revert, because this recovery \
+machinery is itself an untested change. It does not touch /boot, sshd, networkd or wpa_supplicant, \
+and it deliberately leaves zram.service masked (issue #17: unmasking restores a unit that fails \
+every boot and sizes swap at 90% of RAM). \
+\
+This recipe is the tree home and single source of truth for the script. It is DELIBERATELY installed \
+into no image: the script is placed on /data by tools/provision.sh, because /data survives an A/B \
+flip and a reflash and is present regardless of which image version booted -- a per-slot rootfs \
+install is not. Because it ships no service and is in no IMAGE_INSTALL, ci-guards.sh guard 7 (auto- \
+enabled service reachability) cannot see it; guard 8 checks the /data placement path instead."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://kiosk-recover"
+S = "${WORKDIR}"
+
+# No do_install and no IMAGE_INSTALL on purpose (see DESCRIPTION): delivery is
+# tools/provision.sh -> /data/RECOVER.sh, not a rootfs package. This recipe
+# exists so the script has a versioned home under the layer and is linted by
+# ci-guards.sh guard 3 like every other shipped script.
+do_install() {
+    :
+}

--- a/tools/ci-guards.sh
+++ b/tools/ci-guards.sh
@@ -283,6 +283,10 @@ else
     # install/cp command whose target is RECOVER.sh. Comments are stripped first
     # so a mention in prose cannot green the guard. grep -c, not `| grep -q`
     # (pipefail inverts a match -- see the note above), counts placement commands.
+    # Heuristic: recognizes install/cp (a tar/cat placement would need this
+    # widened). The real backstop is provision.sh's own delivery verify -- both
+    # card and device modes read RECOVER.sh back -- so a miss here fails at
+    # provision time, not silently.
     placements=$(grep -vE '^[[:space:]]*#' "$recover_placer" \
         | grep -cE '(install|cp)[[:space:]].*RECOVER\.sh')
     if [ "$placements" -eq 0 ]; then

--- a/tools/ci-guards.sh
+++ b/tools/ci-guards.sh
@@ -94,6 +94,7 @@ fi
 # runs this script, so a syntax error in it disarms every guard here.
 scan3="meta-wisekiosk/recipes-core/kiosk-netcheck/files/kiosk-netcheck \
        meta-wisekiosk/recipes-core/kiosk-provision/files/kiosk-provision \
+       meta-wisekiosk/recipes-core/kiosk-recover/files/kiosk-recover \
        meta-wisekiosk/recipes-core/kiosk-session/files/kiosk-launch \
        .githooks/pre-commit"
 missing3=""
@@ -258,6 +259,36 @@ else
         else
             ok "every auto-enabled service recipe is reachable from an image"
         fi
+    fi
+fi
+
+# --- 8. the recovery script must be wired into the /data placement path ----
+# The kiosk-recover script (issue #28) lives on /data, not the rootfs, so guard
+# 7 -- which polices auto-enabled rootfs SERVICES reaching an image -- is blind
+# to it by construction: no service, in no IMAGE_INSTALL. Its own reachability
+# check is that tools/provision.sh (the /data placement path) actually copies
+# it. Two ways this silently breaks and both fail here: the script goes missing
+# from its recipe home, or provision.sh stops referencing it (a rename, a
+# refactor). Paths are existence-checked first, as 1b/3/7, so neither can read
+# green by disappearing.
+recover_src="meta-wisekiosk/recipes-core/kiosk-recover/files/kiosk-recover"
+recover_placer="tools/provision.sh"
+if [ ! -f "$recover_src" ]; then
+    bad "guard 8: recovery script missing at $recover_src -- nothing to place on /data"
+elif [ ! -f "$recover_placer" ]; then
+    bad "guard 8: $recover_placer missing -- the /data placement path is gone"
+else
+    # Not "is the path named" -- a comment or the RECOVER_SRC= assignment would
+    # satisfy that -- but "is the script actually placed": a non-comment
+    # install/cp command whose target is RECOVER.sh. Comments are stripped first
+    # so a mention in prose cannot green the guard. grep -c, not `| grep -q`
+    # (pipefail inverts a match -- see the note above), counts placement commands.
+    placements=$(grep -vE '^[[:space:]]*#' "$recover_placer" \
+        | grep -cE '(install|cp)[[:space:]].*RECOVER\.sh')
+    if [ "$placements" -eq 0 ]; then
+        bad "guard 8: $recover_placer names but does not place the recovery script (no install/cp of RECOVER.sh) -- not wired onto /data"
+    else
+        ok "recovery script is wired into the /data placement path"
     fi
 fi
 

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -118,14 +118,22 @@ case "$MODE" in
     mode=$(stat -c %a "$DEST/config/wpa_supplicant.conf")
     [ "$mode" = "600" ] || say "wpa_supplicant.conf is mode $mode, must be 600"
 
-    # RECOVER.sh delivery is a thing the write can get wrong (a full or ro card),
-    # and the device branch already reads it back -- verify it here too.
-    [ -f "$DEST/RECOVER.sh" ] || say "RECOVER.sh not delivered to $DEST -- recovery script missing"
-    for f in "$DEST/config/"* "$DEST/etc/machine-id" "$DEST/RECOVER.sh"; do
-        [ -e "$f" ] || continue
+    for f in "$DEST/config/"* "$DEST/etc/machine-id"; do
         own=$(stat -c %u:%g "$f")
         [ "$own" = "0:0" ] || say "$f is owned by $own, must be 0:0 -- re-run as root"
     done
+
+    # RECOVER.sh delivery is a thing the write can get wrong (a full or ro card);
+    # the device branch reads it back, so verify it here too. Checked on its own,
+    # not folded into the loop above: a missing file gives a clean VERIFY FAIL
+    # rather than a stat crash, and the loop keeps its loud failure on any other
+    # missing literal path (machine-id).
+    if [ -f "$DEST/RECOVER.sh" ]; then
+        own=$(stat -c %u:%g "$DEST/RECOVER.sh")
+        [ "$own" = "0:0" ] || say "$DEST/RECOVER.sh is owned by $own, must be 0:0 -- re-run as root"
+    else
+        say "RECOVER.sh not delivered to $DEST -- recovery script missing"
+    fi
 
     if [ "$bad" -ne 0 ]; then
         echo "NOT provisioned -- do not boot this card" >&2

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -118,7 +118,11 @@ case "$MODE" in
     mode=$(stat -c %a "$DEST/config/wpa_supplicant.conf")
     [ "$mode" = "600" ] || say "wpa_supplicant.conf is mode $mode, must be 600"
 
-    for f in "$DEST/config/"* "$DEST/etc/machine-id"; do
+    # RECOVER.sh delivery is a thing the write can get wrong (a full or ro card),
+    # and the device branch already reads it back -- verify it here too.
+    [ -f "$DEST/RECOVER.sh" ] || say "RECOVER.sh not delivered to $DEST -- recovery script missing"
+    for f in "$DEST/config/"* "$DEST/etc/machine-id" "$DEST/RECOVER.sh"; do
+        [ -e "$f" ] || continue
         own=$(stat -c %u:%g "$f")
         [ "$own" = "0:0" ] || say "$f is owned by $own, must be 0:0 -- re-run as root"
     done

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -22,6 +22,16 @@ DEST=${2:?usage: provision.sh device <ssh-target> | card <mounted-/data>}
 # leftover ${WIFI_SSID} expands to empty and breaks loudly instead of silently
 # baking a real credential into a bundle.
 SEC=${KIOSK_SECRETS:-$HOME/.config/wisekiosk/secrets.yaml}
+
+# The recovery script (issue #28) is placed on /data, not the rootfs, so it
+# survives an A/B flip and a reflash. Its single source of truth is the
+# kiosk-recover recipe's files/ dir; provisioning is the /data placement path,
+# so it is copied to /data/RECOVER.sh here. ci-guards.sh guard 8 fails if this
+# wiring is broken (script missing, or provision.sh no longer references it).
+REPO=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+RECOVER_SRC="$REPO/meta-wisekiosk/recipes-core/kiosk-recover/files/kiosk-recover"
+[ -r "$RECOVER_SRC" ] || { echo "recovery script missing at $RECOVER_SRC"; exit 1; }
+
 [ -r "$SEC" ] || {
     echo "no secrets at $SEC"
     echo "copy secrets.yaml.tmpl there and fill it in, or set KIOSK_SECRETS"
@@ -69,6 +79,7 @@ printf '%s\n' "$HOST" > "$STAGE/config/hostname"
 : > "$STAGE/config/resolv.conf"
 for ns in $NS; do printf 'nameserver %s\n' "$ns" >> "$STAGE/config/resolv.conf"; done
 printf '%s\n' "$MID" > "$STAGE/etc/machine-id"
+install -m 0755 "$RECOVER_SRC" "$STAGE/RECOVER.sh"
 
 case "$MODE" in
   card)
@@ -76,8 +87,11 @@ case "$MODE" in
     mkdir -p "$DEST/config" "$DEST/etc"
     cp "$STAGE/config/"* "$DEST/config/"
     cp "$STAGE/etc/machine-id" "$DEST/etc/machine-id"
+    cp "$STAGE/RECOVER.sh" "$DEST/RECOVER.sh"
     chown -R 0:0 "$DEST/config" "$DEST/etc" 2>/dev/null || echo "note: run as root to own the files correctly"
+    chown 0:0 "$DEST/RECOVER.sh" 2>/dev/null || true
     chmod 0600 "$DEST/config/wpa_supplicant.conf"
+    chmod 0755 "$DEST/RECOVER.sh"
 
     # Verify here, not in a procedure someone is told to follow. The failure
     # this catches is discovered on the device otherwise, and a card that comes
@@ -134,7 +148,7 @@ case "$MODE" in
     [ "$rc" -eq 0 ] || { echo "could not write /data on $DEST (tar|ssh rc=$rc) -- nothing was provisioned" >&2; exit 1; }
 
     rc=0
-    ssh "${ssh_opts[@]}" "$DEST" 'ls -l /data/config /data/etc/machine-id' || rc=$?
+    ssh "${ssh_opts[@]}" "$DEST" 'ls -l /data/config /data/etc/machine-id /data/RECOVER.sh' || rc=$?
     [ "$rc" -eq 0 ] || { echo "wrote /data on $DEST but could not read it back (ssh rc=$rc) -- check it by hand" >&2; exit 1; }
     echo "provisioned $DEST"
     ;;


### PR DESCRIPTION
Builds the kiosk-recover recovery script (#28): reverses kiosk-hardware's boot trims for a debugging session, then reboots. Not a boot un-bricker — runs on a slot that already gives a shell.

- Unmasks the 4 boot-trim units; **skips `zram.service`** (issue #17: that mask is a defect workaround, not a trim).
- Deletes only `-type l` `/dev/null` udev masks (never a `*.rules` glob).
- Comments only the 6 Bluetooth lines in the combined `kiosk-blacklist.conf`; other passes survive. Never deletes the file.
- Restores the `/etc/resolv.conf -> /data/config/resolv.conf` symlink; reboots. Idempotent; `--dry-run` supported.
- Touches nothing in `/boot`, `sshd`, networkd, or `wpa_supplicant`.

**Placement:** `/data` via `tools/provision.sh` (survives an A/B flip and reflash). Guard 7 can't see a non-service `/data` script, so **guard 8** enforces that `provision.sh` actually *places* it — proven to fail when the placement command is removed.

**Verification:** independent review (no blocking findings) + ci-guards green + a reversible destructive hardware proof on the bench — recovery reversed exactly the 4 trim classes (zram left masked, 3 real udev rules spared, only 6 BT lines changed), then the board was restored to hardened state and verified across a reboot.

The `login1` "Call to Reboot failed" line is a property of the hardened image (logind masked) — present on a plain reboot too, not a kiosk-recover defect.