### PR TITLE
docs: durable issue-investigation template with mandatory traceability

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 |---|---|
 | [`layers-and-kas.md`](layers-and-kas.md) | How does a tree of YAML and recipes become an image, for someone who has not used Yocto? |
 | [`rauc-key-rotation.md`](rauc-key-rotation.md) | How do you replace the RAUC signing key the devices trust, and why must it happen in a fixed order? |
+| [`issue_investigation/TEMPLATE.md`](issue_investigation/TEMPLATE.md) | What shape must an issue investigation take, and what must every test run in it name? |
 | [`issue_investigation/boot_cpu_saturation/`](issue_investigation/boot_cpu_saturation/README.md) | Across a boot, is the single core doing work, waiting on hardware, or queued behind something else? |
 | [`issue_investigation/wlan0_udev_queue/`](issue_investigation/wlan0_udev_queue/README.md) | What occupies the gap between the WiFi chip appearing on the bus and `wlan0` existing, and what is removing it worth? |
 | [`issue_investigation/first_boot_after_ota/`](issue_investigation/first_boot_after_ota/README.md) | What does the first boot of a freshly written slot cost, and how long is the device unreachable? |
@@ -13,6 +14,12 @@
 | [`issue_investigation/screenshot_capture_fbgrab/`](issue_investigation/screenshot_capture_fbgrab/README.md) | Which framebuffer capture path produces a screenshot that can be trusted as a liveness check? |
 | [`issue_investigation/webkit_dependency_trims/`](issue_investigation/webkit_dependency_trims/README.md) | Can the accessibility stack be taken out of the image, from the build side or at runtime? |
 
-Each investigation is a directory whose `README.md` carries exactly four sections in this order —
-*Configuration under test*, *How the test was performed*, *Metrics*, *Changes configured as a
-result* — with any raw captures as siblings beside it; match that shape when adding the next one.
+Each investigation is a directory whose `README.md` is the record of record, with any raw captures
+as siblings beside it. [`issue_investigation/TEMPLATE.md`](issue_investigation/TEMPLATE.md) is the
+authoritative shape — copy it as the new `README.md` and fill every field. It carries three rules:
+
+- **R1** Every test run names its board (role) and the image commit it ran.
+- **R2** Every script put on a board is either shipped (link its recipe/PR) or one-off (committed in
+  the investigation directory beside its `README.md`) — never left only in `local/`.
+- **R3** Runs are never blended: one board × one build × one test = one run, and numbers from
+  different runs never share a table.

--- a/docs/issue_investigation/TEMPLATE.md
+++ b/docs/issue_investigation/TEMPLATE.md
@@ -1,0 +1,66 @@
+<!--
+  ISSUE INVESTIGATION TEMPLATE — copy this file to a new directory as README.md,
+  fill every field, delete these comments.
+  One investigation = one directory. That README.md is the record of record.
+  Hard rules:
+    R1  Every test run names its BOARD (role) and the IMAGE COMMIT it ran.
+    R2  Every script put on a board is either SHIPPED (link its recipe/PR) or ONE-OFF
+        (committed in this directory beside this README). Never left only in local/ or hot-swapped
+        without a tracked source.
+    R3  Runs are NEVER blended. One board × one build × one test = one run. Numbers from different
+        runs never share a table.
+  Example file names below are backticked, not linked: `just links` resolves every Markdown link
+  in the tree, and a link to a capture that does not exist yet fails it. Link them once the real
+  files sit beside the README.
+-->
+
+# <the question this investigation answers, in one line>
+
+| | |
+|---|---|
+| **Issue** | #NN &lt;name&gt; |
+| **Status** | open · concluded → code change · concluded → no change |
+| **Opened / concluded** | YYYY-MM-DD / YYYY-MM-DD |
+
+<one-paragraph abstract: the question, and the answer if concluded. No narration.>
+
+## Test runs
+
+<!-- One row per (board × image build × test). A `### Run N` block below expands each. -->
+
+| Run | Board (role) | Image commit | Harness / scripts | Result (1 line) |
+|---|---|---|---|---|
+| 1 | bench · Pi Zero W | `<sha>` | `collect.sh` — one-off | |
+| 2 | prod · Pi Zero W | `<sha>` | `kiosk-soak` — durable, PR #NN | |
+
+### Run 1 — <board role>, commit `<sha>`
+
+- **Board:** role label only (bench / prod) + hardware model. NO IP, hostname, MAC, or serial — this repo is public.
+- **Image commit:** `<full git sha the running image was built from>`, confirmed by `<baked /etc/build-info | built+flashed from this commit on YYYY-MM-DD>`. An unverifiable "probably this build" is not a commit — leave the run out until you can name it.
+- **Scripts deployed (each, with disposition):**
+  - `<name>` — ONE-OFF, not shipped → committed here beside this README.
+  - `<name>` — DURABLE → ships via `<recipe path>`, PR #NN.
+- **Procedure:** exact steps — reboot count / sampling cadence / commands / bound conditions. Reproducible from this text alone.
+- **Raw capture:** sibling file(s), e.g. `run1-boots.log`.
+
+### Run 2 — …
+
+## Configuration under test
+
+The tree facts the runs rest on. Cite every claim `file:line`.
+
+## Metrics
+
+Per run. One table per run — never merge runs of different board / build / N.
+
+## Findings
+
+What the data shows; each hypothesis tested and its disposition (dropped / open / confirmed), tied to the run that decided it.
+
+## Changes configured as a result
+
+Exactly one durable outcome, stated plainly:
+- **Code change** → link the recipe/PR that ships it; or
+- **No change** → the decision and why, and that the issue is closed with that rationale.
+
+Every one-off script named above is committed in this directory. Every durable change links to its recipe/PR.


### PR DESCRIPTION
Adds `docs/issue_investigation/TEMPLATE.md` — the shape every future investigation copies as its `README.md` — and repoints `docs/README.md` at it.

## What it supersedes

`docs/README.md` closed with a loose convention: *"exactly four sections in this order — Configuration under test, How the test was performed, Metrics, Changes configured as a result."* That names an order and no mandatory fields. An investigation could satisfy it in full while leaving the board it ran on, the image commit that board was running, and the provenance of every script pushed to it unstated — which is exactly how #31 intermittent timesync produced numbers no one could later re-derive. The template replaces that paragraph as the authoritative shape.

## The three rules

- **R1 — board + commit per run.** Every test run names its board by role (bench / prod) plus hardware model, and the full image commit it ran, with how that commit was confirmed. An unverifiable "probably this build" is not a commit; the run stays out until it can be named. Role labels only — no IP, hostname, MAC or serial, this repo is public.
- **R2 — scripts shipped or committed beside the README.** Every script put on a board carries a disposition: DURABLE (ships via a named recipe, PR linked) or ONE-OFF (committed in the investigation directory next to its `README.md`). Never left only in `local/`, never hot-swapped without a tracked source.
- **R3 — runs are never blended.** One board × one build × one test = one run. Numbers from different runs never share a table, and each run gets its own metrics table.

## What this enables

- **#46 image stamps no build commit** — R1 is the requirement #46 exists to make satisfiable. Today the image bakes no build commit, so naming one rests on operator memory; #46 stamps it, and R1 is what consumes the stamp.
- **The #31 rerun** — #31's investigation is to be redone under this template, with each board × build × test recorded as its own run rather than a merged set.

## Scope

- No existing investigation directory is touched. Rewrites of the eight current ones are separate work.
- **No ci-guard.** Enforcement of R1/R2/R3 is a deliberate follow-up PR; the draft's comment block claiming a guard enforces them was trimmed to match reality.
- Example script and capture names in the template are backticked rather than Markdown-linked. `just links` resolves every link in the tree, and a link to a capture the investigation has not taken yet fails the check; the template says to link them once the real files sit beside the README.

## Verification

`just verify` and `just guards` both pass. Link check against `origin/main` baseline: 55 file references across 14 Markdown files, all resolving; after this change 57 across 15, all resolving — the two new references are the table row and the pointer paragraph, and no existing link broke.

Draft — enforcement follow-up and owner review pending.