### PR TITLE
feat(#46): bake the source commit into the image at /etc/build-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,12 @@ sources/
 .kas_shell_history
 secrets.yaml
 
+# Agent scratch space. Present in most sessions, and `git status --porcelain` at
+# the repository root is what META_WISEKIOSK_DIRTY reads, so leaving it untracked
+# pins every image to DIRTY=1 -- an always-on warning carries no signal, and a
+# genuinely dirty build then looks identical to a clean one.
+scratchpad/
+
 # Operator notes -- serials, MACs, addresses, readings -- which together
 # fingerprint one network, and local/keys, the RAUC key the fleet trusts. Both
 # must live in the tree, so NOT COMMITTING them is the whole protection.

--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,7 @@ sources/
 .kas_shell_history
 secrets.yaml
 
-# Agent scratch space. Present in most sessions, and `git status --porcelain` at
-# the repository root is what META_WISEKIOSK_DIRTY reads, so leaving it untracked
-# pins every image to DIRTY=1 -- an always-on warning carries no signal, and a
-# genuinely dirty build then looks identical to a clean one.
+# Agent scratch space. Untracked, it would pin META_WISEKIOSK_DIRTY to 1.
 scratchpad/
 
 # Operator notes -- serials, MACs, addresses, readings -- which together

--- a/Justfile
+++ b/Justfile
@@ -91,7 +91,7 @@ spotless: clean
 
 # Run the same checks CI runs. Fast, needs no build.
 [group('guards')]
-[doc("Run repository guards: secrets, template, shell syntax, YAML, gitleaks")]
+[doc("Run repository guards: secrets, template, shell syntax, YAML, gitleaks, build stamp")]
 guards:
     tools/ci-guards.sh
 
@@ -131,6 +131,14 @@ links:
 [doc("Check docs against what the built image ships (skips if unbuilt)")]
 image:
     python3 tools/doc-image.py check
+
+# The commit the built image names, read out of the shipped .ext4. Local-only
+# for the same reason as `image`. `just flash` and `just kiosk-preflight` run it
+# with --require, where an unreadable stamp fails instead of skipping.
+[group('check')]
+[doc("Check the built image names its source commit (skips if unbuilt)")]
+build-stamp:
+    tools/build-stamp-check.sh
 
 # Write per-site config to a device's /data. The image carries none of it.
 [group('provision')]

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ behind those changes are indexed in **[docs/README.md](docs/README.md)**.
 
 Every image carries **`/etc/build-info`**: the `meta-wisekiosk` commit it was built from, whether that
 tree was modified, the branch, and the machine/distro. It lives in the rootfs the `.raucb` packages,
-so it should be per-slot — `cat /etc/build-info` on a device naming the build that slot is running is
-the fact an investigation has to be able to quote. Not yet confirmed on a booted device.
+so it is per-slot — `cat /etc/build-info` on a device names the build that slot is running, which is
+the fact an investigation has to be able to quote.
 `just build-stamp` reads it back out of the built `.ext4`, and `just flash` and `just kiosk-preflight`
 refuse an artifact that cannot name its commit. See
 [docs/layers-and-kas.md](docs/layers-and-kas.md#what-commit-an-image-was-built-from).

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ meta-wisekiosk/                    <- the repository (project scaffolding)
 │   ├── classes/
 │   └── recipes-*/
 ├── Justfile, justfiles/           build, OTA and device commands
-├── tools/                         provisioning, bundle delivery, device debugging, doc gate, CI guards
+├── tools/                         provisioning, bundle delivery, device debugging, doc gate, build stamp, CI guards
 ├── docs/                          layers-and-kas.md, issue_investigation/
 └── sources/                       gitignored; everything kas fetches lands here
 ```
@@ -60,6 +60,14 @@ a layer is, what kas does with these files, and why the two patches cannot be bb
 
 Every change that was acted on is documented at the recipe carrying it; the per-issue investigations
 behind those changes are indexed in **[docs/README.md](docs/README.md)**.
+
+Every image carries **`/etc/build-info`**: the `meta-wisekiosk` commit it was built from, whether that
+tree was modified, the branch, and the machine/distro. It lives in the rootfs the `.raucb` packages,
+so it should be per-slot — `cat /etc/build-info` on a device naming the build that slot is running is
+the fact an investigation has to be able to quote. Not yet confirmed on a booted device.
+`just build-stamp` reads it back out of the built `.ext4`, and `just flash` and `just kiosk-preflight`
+refuse an artifact that cannot name its commit. See
+[docs/layers-and-kas.md](docs/layers-and-kas.md#what-commit-an-image-was-built-from).
 
 ## Quick start
 
@@ -134,7 +142,9 @@ reachable device; the device reads it at boot.
 The tracked `secrets.yaml.tmpl` carries names with empty values only. `tools/ci-guards.sh` — run by
 CI and by the pre-commit hook — rejects a `secrets.yaml` at the repository root (the only place kas
 would pick one up), and fails if any of those value names becomes a build input again in the kas
-config, the layer, `includes/` or `patches/`. Install the hook with `just install-hooks`.
+config, the layer, `includes/` or `patches/`. It also fails if the build-stamp *wiring* is removed or
+renamed — CI never builds, so it cannot see the baked file. Checking the file itself is
+`just build-stamp`'s job, host-side, against the artifact. Install the hook with `just install-hooks`.
 
 **kas merges `local_conf_header` by block name and the top-level file wins**, so a block named the
 same as one in `kiosk-zero-w.yaml` is discarded silently — no warning, no error, variables that never

--- a/docs/layers-and-kas.md
+++ b/docs/layers-and-kas.md
@@ -218,8 +218,14 @@ Four things about it are load-bearing:
   exact name and resolves to nothing — the body, and every value in it, reaches no task hash.
   `oe/utils.py` meanwhile does `cmds.replace(";", " ")` before executing, so it runs perfectly. Two
   consumers of one string with opposite parsers: the file is written once and then frozen while the
-  source moves. This shipped, was caught only by a real build, and is now gated by guard 9 across
-  every class in the layer.
+  source moves. What turns a function *name* into a dependency is the anonymous python in
+  `image.bbclass` — `d.setVarFlag(var, 'vardeps', d.getVar(var))` — not `rootfs_variables()`, which
+  contributes the variable names. The trap belongs to the variable, not to this class: OE feeds
+  twelve `*_(PRE|POST)*_COMMAND` names through `rootfs_command_variables()`, and
+  `SDK_POSTPROCESS_COMMAND` behaves the same way. Guard 9 rejects the form across the layer's
+  classes, recipes and bbappends and across every kas build input (`kiosk-zero-w.yaml`,
+  `includes/*.yaml`). The spaced form `func ;` is left alone: the `;` is then its own token, which
+  reaches no hash but takes nothing with it.
 - **`DIRTY` is `git status --porcelain` over the whole repository, so an untracked file counts.**
   Same scope as the sha above it, which is the repository's HEAD, not the layer's — `kiosk-zero-w.yaml`,
   `includes/` and `patches/` are build inputs living outside the layer. OE's `is_layer_modified` is
@@ -231,7 +237,8 @@ upstream layer, or a signing key rotated in `local/keys`, moves the image withou
 `META_WISEKIOSK_COMMIT`.
 
 Verification splits in two, because CI never builds. `tools/ci-guards.sh` guard 9 checks the wiring
-still exists and that no postprocess function anywhere in the layer carries the semicolon above;
+still exists — the hook, the written path and key, the `INHERIT`, that both call sites still invoke
+the checker, and that no command variable anywhere carries the semicolon above;
 `tools/build-stamp-check.sh` (`just build-stamp`) reads the file back out of the
 shipped `.ext4` with `debugfs` and rejects the `<unknown>` that git failing inside kas-container
 would leave. `just flash` and `just kiosk-preflight` run it with `--require`.

--- a/docs/layers-and-kas.md
+++ b/docs/layers-and-kas.md
@@ -182,6 +182,60 @@ debugfs -R "cat /etc/systemd/system/wpa_supplicant.service" \
 
 and confirm it reads `/data/config/wpa_supplicant.conf` and requires `data.mount`.
 
+## What commit an image was built from
+
+`meta-wisekiosk/classes/kiosk-buildstamp.bbclass`, globally inherited from `kiosk-zero-w.yaml`,
+writes `/etc/build-info` in a rootfs postprocess:
+
+```
+BUILD_INFO_VERSION="1"
+META_WISEKIOSK_COMMIT="<40 hex>"        META_WISEKIOSK_DIRTY="0|1"
+META_WISEKIOSK_COMMIT_SHORT="<12 hex>"  META_WISEKIOSK_BRANCH="<name>"
+BUILD_MACHINE=  BUILD_DISTRO=  BUILD_DISTRO_VERSION=  BUILD_LAYERS="name:sha …"
+```
+
+Every value is quoted, including those that cannot contain a space: the designed failure value is the
+literal `<unknown>`, and unquoted, `<` `>` are redirection operators — `. /etc/build-info` would die
+on a syntax error, leave the field empty rather than `<unknown>`, and abandon every later line. Only
+`META_WISEKIOSK_DIRTY` answers "was the tree modified"; `BUILD_LAYERS` deliberately carries no dirty
+marker, because OE's per-layer flag is `git diff` (tracked only) and would call a tree clean that
+`DIRTY` calls dirty.
+
+Four things about it are load-bearing:
+
+- **The sha comes from `BBLAYERS`, not `COREBASE`.** `oe.buildcfg.get_scmbasepath` joins `COREBASE`
+  with `meta`, which is why OE's own `METADATA_REVISION` reports poky's HEAD — already pinned in
+  `includes/base.yaml`, and never this repository's commit. `meta-wisekiosk` is the one layer kas
+  does not clone, so git inside it answers with this working tree.
+- **It is captured in configuration space with `:=` and a `[vardepvalue]`**, copying
+  `metadata_scm.bbclass`. A package recipe running `git` in `do_install` instead would produce a task
+  hash bitbake cannot invalidate: sstate would replay the old package and every later image would bake
+  the first commit ever built — a file that exists, parses and is wrong. Image tasks carry
+  `SSTATE_SKIP_CREATION`, so this route has no cache to replay.
+- **The function is appended to `ROOTFS_POSTPROCESS_COMMAND` with no trailing semicolon**, and this
+  is correctness, not style. `image.bbclass` installs that variable's value as its own `vardeps` and
+  bitbake splits it on whitespace, so `kiosk_write_build_info;` is looked up as a variable of that
+  exact name and resolves to nothing — the body, and every value in it, reaches no task hash.
+  `oe/utils.py` meanwhile does `cmds.replace(";", " ")` before executing, so it runs perfectly. Two
+  consumers of one string with opposite parsers: the file is written once and then frozen while the
+  source moves. This shipped, was caught only by a real build, and is now gated by guard 9 across
+  every class in the layer.
+- **`DIRTY` is `git status --porcelain` over the whole repository, so an untracked file counts.**
+  Same scope as the sha above it, which is the repository's HEAD, not the layer's — `kiosk-zero-w.yaml`,
+  `includes/` and `patches/` are build inputs living outside the layer. OE's `is_layer_modified` is
+  `git diff` only, and a new untracked `.bb` is picked up by `BBFILES` — it is in the image while
+  reading clean. A dirty build is recorded, never refused.
+
+`BUILD_LAYERS` narrows but does not close the gap that `sources/` is gitignored: a hand-patched
+upstream layer, or a signing key rotated in `local/keys`, moves the image without moving
+`META_WISEKIOSK_COMMIT`.
+
+Verification splits in two, because CI never builds. `tools/ci-guards.sh` guard 9 checks the wiring
+still exists and that no postprocess function anywhere in the layer carries the semicolon above;
+`tools/build-stamp-check.sh` (`just build-stamp`) reads the file back out of the
+shipped `.ext4` with `debugfs` and rejects the `<unknown>` that git failing inside kas-container
+would leave. `just flash` and `just kiosk-preflight` run it with `--require`.
+
 ## Bumping the upstream pin
 
 Upstream is dormant, and the pin is deliberate — a floating branch would make every rebuild's diff

--- a/justfiles/deploy.just
+++ b/justfiles/deploy.just
@@ -106,6 +106,12 @@ flash device:
     fi
     echo "verified: image bakes the fleet keyring ($BAKED_FP)"
 
+    # Same .ext4, same fail-closed reason: a card whose image cannot name its
+    # source commit produces an investigation nobody can attribute later. A
+    # DIRTY build is reported and flashed -- refusing that would make the
+    # develop loop hostile.
+    tools/build-stamp-check.sh --require "$ROOTFS"
+
     echo "Flashing $IMAGE to {{device}}..."
     echo "WARNING: This will overwrite all data on {{device}}!"
     # `|| true`: read exits non-zero at EOF, which errexit would turn into an

--- a/justfiles/deploy.just
+++ b/justfiles/deploy.just
@@ -106,10 +106,7 @@ flash device:
     fi
     echo "verified: image bakes the fleet keyring ($BAKED_FP)"
 
-    # Same .ext4, same fail-closed reason: a card whose image cannot name its
-    # source commit produces an investigation nobody can attribute later. A
-    # DIRTY build is reported and flashed -- refusing that would make the
-    # develop loop hostile.
+    # Fail-closed: a card that cannot name its source commit is unattributable.
     tools/build-stamp-check.sh --require "$ROOTFS"
 
     echo "Flashing $IMAGE to {{device}}..."

--- a/justfiles/ota.just
+++ b/justfiles/ota.just
@@ -154,19 +154,8 @@ kiosk-preflight image="build/tmp-raspberrypi0-wifi/deploy/images/raspberrypi0-wi
 
     test -f "{{image}}"  || { echo "no rootfs image at {{image}}"; exit 1; }
     test -f "{{bundle}}" || { echo "no bundle at {{bundle}}"; exit 1; }
-    # An image that cannot name its source commit installs a slot nobody can
-    # attribute afterwards. Fail-closed here, before the ~114MB transfer.
-    #
-    # ASSUMPTION: the bundle packages the rootfs this .ext4 was made from, so a
-    # green stamp here describes what gets delivered. NOTHING CHECKS THAT. The
-    # stamp is readable from the .ext4 and not from the .raucb, and the two are
-    # deployed by different recipes, so a stale bundle beside a fresh image
-    # passes. The filename tie `just flash` uses (deploy.just:51-59) does NOT
-    # transfer: DATETIME is fixed per bitbake INVOCATION, and `just build` then
-    # `just kiosk-bundle` is two invocations, so matching stamps would refuse the
-    # documented sequence. The honest tie is content-based -- the bundle
-    # manifest's image hash against the .ext4 -- and is tracked as
-    # #48 bundle-image-tie, not solved here.
+    # Fail-closed before the ~114MB transfer. Assumes the bundle packages this
+    # rootfs; nothing binds them -- see #48 bundle-image-tie.
     tools/build-stamp-check.sh --require "{{image}}"
 
     IMAGE_B=$(stat -Lc %s "{{image}}")

--- a/justfiles/ota.just
+++ b/justfiles/ota.just
@@ -147,13 +147,28 @@ kiosk-bundle kconfig="kiosk-zero-w.yaml":
 # transfer completes, or does not surface at all.
 [group('ota')]
 [script('bash')]
-[doc("Refuse a delivery that cannot work: slot size, stale bundle, /data space")]
+[doc("Refuse a delivery that cannot work: image stamp, slot size, stale staged copy, /data space")]
 kiosk-preflight image="build/tmp-raspberrypi0-wifi/deploy/images/raspberrypi0-wifi/core-image-base-raspberrypi0-wifi.rootfs.ext4" bundle="build/tmp-raspberrypi0-wifi/deploy/images/raspberrypi0-wifi/update-bundle-raspberrypi0-wifi.raucb" host=kiosk-host:
     set -euo pipefail
     SSH="ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
 
     test -f "{{image}}"  || { echo "no rootfs image at {{image}}"; exit 1; }
     test -f "{{bundle}}" || { echo "no bundle at {{bundle}}"; exit 1; }
+    # An image that cannot name its source commit installs a slot nobody can
+    # attribute afterwards. Fail-closed here, before the ~114MB transfer.
+    #
+    # ASSUMPTION: the bundle packages the rootfs this .ext4 was made from, so a
+    # green stamp here describes what gets delivered. NOTHING CHECKS THAT. The
+    # stamp is readable from the .ext4 and not from the .raucb, and the two are
+    # deployed by different recipes, so a stale bundle beside a fresh image
+    # passes. The filename tie `just flash` uses (deploy.just:51-59) does NOT
+    # transfer: DATETIME is fixed per bitbake INVOCATION, and `just build` then
+    # `just kiosk-bundle` is two invocations, so matching stamps would refuse the
+    # documented sequence. The honest tie is content-based -- the bundle
+    # manifest's image hash against the .ext4 -- and is tracked as
+    # #48 bundle-image-tie, not solved here.
+    tools/build-stamp-check.sh --require "{{image}}"
+
     IMAGE_B=$(stat -Lc %s "{{image}}")
     BUNDLE_B=$(stat -Lc %s "{{bundle}}")
 

--- a/kiosk-zero-w.yaml
+++ b/kiosk-zero-w.yaml
@@ -163,6 +163,15 @@ local_conf_header:
     # provisioning.
     INHERIT += "kiosk-static-resolv"
 
+    # /etc/build-info: the meta-wisekiosk commit the running slot was built
+    # from. DISTRO_VERSION is a hardcoded "0.1", /etc/os-release derives from
+    # it, and /etc/version is the reproducibility epoch clamp, so without this
+    # no image can name its own source (issue #46). A global INHERIT is
+    # configuration space, re-parsed on every bitbake invocation, so
+    # `just build`, `just kiosk-bundle` and tools/rauc-rotate-build.sh -- which
+    # each reach bitbake by their own route -- all get the stamp.
+    INHERIT += "kiosk-buildstamp"
+
   # update-bundle.bb packages whichever image RAUC_SLOT_rootfs names, and its
   # default is autonomos-devel -- a different image, with no surf and no kiosk
   # unit. Installing that bundle would replace the slot and report success.

--- a/kiosk-zero-w.yaml
+++ b/kiosk-zero-w.yaml
@@ -163,13 +163,8 @@ local_conf_header:
     # provisioning.
     INHERIT += "kiosk-static-resolv"
 
-    # /etc/build-info: the meta-wisekiosk commit the running slot was built
-    # from. DISTRO_VERSION is a hardcoded "0.1", /etc/os-release derives from
-    # it, and /etc/version is the reproducibility epoch clamp, so without this
-    # no image can name its own source (issue #46). A global INHERIT is
-    # configuration space, re-parsed on every bitbake invocation, so
-    # `just build`, `just kiosk-bundle` and tools/rauc-rotate-build.sh -- which
-    # each reach bitbake by their own route -- all get the stamp.
+    # /etc/build-info: the commit this slot was built from (#46 image build stamp).
+    # Global INHERIT so every route to bitbake gets it.
     INHERIT += "kiosk-buildstamp"
 
   # update-bundle.bb packages whichever image RAUC_SLOT_rootfs names, and its

--- a/meta-wisekiosk/classes/kiosk-buildstamp.bbclass
+++ b/meta-wisekiosk/classes/kiosk-buildstamp.bbclass
@@ -1,0 +1,202 @@
+# Bake this repository's commit into every image, at ${sysconfdir}/build-info.
+#
+# The three files that look like provenance are not: DISTRO_VERSION is the
+# hardcoded "0.1" upstream sets, /etc/os-release derives from it, and
+# /etc/version is the reproducible-build epoch clamp -- identical on every build
+# of every project. An image built today and one built in June are byte-identical
+# in all three, so a running slot cannot name the source it came from and an
+# investigation cannot attribute what it measured (issue #46).
+#
+# Why a postprocess and not a recipe: a package recipe running `git` inside
+# do_install produces a task hash bitbake cannot invalidate, sstate replays the
+# old .ipk, and every later image bakes the sha of whichever commit happened to
+# be checked out first -- a file that exists, parses, and is WRONG. The image
+# path cannot do that: rootfs_variables() (image.bbclass) puts
+# ROOTFS_POSTPROCESS_COMMAND in do_rootfs[vardeps], bitbake resolves each name in
+# it to a function and hashes that function's body and variable references, so
+# the values below reach the task hash -- see the separator note above
+# ROOTFS_POSTPROCESS_COMMAND, which is what makes that resolution happen. Image
+# tasks also carry SSTATE_SKIP_CREATION, so there is no cached artifact to replay
+# over a changed hash.
+#
+# The capture is in configuration space with := and a [vardepvalue], copying
+# metadata_scm.bbclass: without that flag bitbake hashes the expression text
+# rather than its value, and the sha would never move the hash.
+#
+# NOT recorded: build timestamp, builder hostname, builder username. The latter
+# two are the identifying detail guard 6 exists to keep out of a public
+# repository, arriving by a route no guard watches.
+#
+# The reproducibility unit is therefore commit + branch + dirty state, not commit
+# alone: BRANCH and DIRTY are baked and hashed, and neither is a function of the
+# commit. The same tree built on two branches, or built dirty and then clean,
+# yields different files and re-runs do_rootfs. Excluding a timestamp is what
+# keeps the unit that small -- a timestamp would make even a repeat build of one
+# commit on one branch differ. On a detached checkout `git rev-parse
+# --abbrev-ref HEAD` answers the literal `HEAD`, which is recorded as-is.
+
+def kiosk_layerdir(d):
+    """This layer's path, from BBLAYERS.
+
+    Not COREBASE: oe.buildcfg.get_scmbasepath joins COREBASE with 'meta', which
+    is why METADATA_REVISION reports poky's HEAD -- a kas pin already recorded in
+    includes/base.yaml, and never this repository's commit.
+    """
+    for layer in (d.getVar('BBLAYERS') or '').split():
+        path = os.path.normpath(layer)
+        if os.path.basename(path) == 'meta-wisekiosk':
+            return path
+    return ''
+
+def kiosk_git(d, cmd, cwd=None):
+    """Run git in the layer, or in cwd. None on any failure.
+
+    None rather than '' because the two must not collide: `git status
+    --porcelain` prints nothing on a clean tree, so a failed run that returned ''
+    would report a dirty tree as clean.
+    """
+    import bb.process
+    path = cwd or kiosk_layerdir(d)
+    if not path:
+        return None
+    try:
+        out, _ = bb.process.run(cmd, cwd=path,
+                                env=dict(os.environ, PSEUDO_UNLOAD='1'))
+    except bb.process.CmdError:
+        return None
+    return out.strip()
+
+def kiosk_commit(d):
+    """The full sha of the repository this layer belongs to, or <unknown>.
+
+    <unknown>, not '', so the shipped file records that the build could not
+    attribute itself; tools/build-stamp-check.sh's 40-hex assertion is what turns
+    that into a red flash rather than a quiet wrong answer. Inside kas-container
+    the likely cause is git refusing the bind-mounted tree as dubiously owned.
+
+    git walks upward from the layer, so the answer is the PARENT repository's
+    HEAD -- correct here, where bblayers.conf resolves the layer to a
+    subdirectory of the bind-mounted repository root, and silently about the
+    wrong repository if this layer were ever vendored into a different parent.
+    kiosk-zero-w.yaml is that repository's marker.
+    """
+    top = kiosk_git(d, 'git rev-parse --show-toplevel')
+    if not top:
+        return '<unknown>'
+    if not os.path.exists(os.path.join(top, 'kiosk-zero-w.yaml')):
+        bb.warn('kiosk-buildstamp: %s answers for %s but carries no '
+                'kiosk-zero-w.yaml -- META_WISEKIOSK_COMMIT names a different '
+                'repository than the one this layer was written for'
+                % (top, kiosk_layerdir(d)))
+    return kiosk_git(d, 'git rev-parse HEAD') or '<unknown>'
+
+def kiosk_dirty(d):
+    """1 if the working tree differs from the commit above, tracked or untracked.
+
+    Scoped to the whole repository, matching META_WISEKIOSK_COMMIT, which is the
+    repository's HEAD and not the layer's (owner, 2026-08-18). kiosk-zero-w.yaml,
+    includes/ and patches/ are build inputs living outside the layer, so a
+    layer-scoped flag would read 0 while an uncommitted edit to any of them moved
+    the image.
+
+    git status, not oe.buildcfg.is_layer_modified, which is `git diff` only: a
+    brand-new untracked .bb reads clean there, and BBFILES in conf/layer.conf
+    picks that file up, so it IS in the image. The cost is that a stray editor
+    swapfile flips the flag, which is the intended trade.
+
+    Recorded, never refused. A build that will not run on a dirty tree makes the
+    develop loop hostile; making the fact legible is the whole job, and an
+    investigation quoting META_WISEKIOSK_DIRTY=1 is already disqualified by its
+    own standard. An unreadable tree counts as dirty.
+    """
+    top = kiosk_git(d, 'git rev-parse --show-toplevel')
+    if not top:
+        return '1'
+    status = kiosk_git(d, 'git status --porcelain', cwd=top)
+    return '0' if status == '' else '1'
+
+def kiosk_build_layers(d):
+    """Every layer as name:shortsha, flattened onto one line.
+
+    Informational -- the guard asserts META_WISEKIOSK_COMMIT only. It narrows,
+    and does not close, the gap that sources/ is gitignored: a hand-patched
+    upstream layer or a rotated signing key moves the image without moving this
+    repository's HEAD.
+
+    get_layer_revisions also offers a modified flag; it is dropped rather than
+    emitted. It is `git diff` (tracked only), so it would print a bare
+    meta-wisekiosk token -- read as "clean" -- for a tree META_WISEKIOSK_DIRTY
+    calls dirty. One file must not answer the same question two ways, and DIRTY
+    is the answer meant to be quoted. `path` is likewise discarded: it is the
+    builder's absolute path, and this file ships in a public image.
+    """
+    tokens = []
+    for _path, name, _branch, rev, _modified in oe.buildcfg.get_layer_revisions(d):
+        tokens.append('%s:%s' % (name, rev[:12]))
+    return ' '.join(tokens)
+
+WISEKIOSK_COMMIT := "${@kiosk_commit(d)}"
+WISEKIOSK_COMMIT[vardepvalue] = "${WISEKIOSK_COMMIT}"
+# Sliced from the captured value rather than asked of git again, so the short sha
+# cannot disagree with the long one. 12, not 7: the field is meant to be quoted
+# in an investigation write-up years after the tree outgrew 7.
+WISEKIOSK_COMMIT_SHORT := "${@d.getVar('WISEKIOSK_COMMIT')[:12]}"
+WISEKIOSK_COMMIT_SHORT[vardepvalue] = "${WISEKIOSK_COMMIT_SHORT}"
+WISEKIOSK_DIRTY := "${@kiosk_dirty(d)}"
+WISEKIOSK_DIRTY[vardepvalue] = "${WISEKIOSK_DIRTY}"
+WISEKIOSK_BRANCH := "${@kiosk_git(d, 'git rev-parse --abbrev-ref HEAD') or '<unknown>'}"
+WISEKIOSK_BRANCH[vardepvalue] = "${WISEKIOSK_BRANCH}"
+WISEKIOSK_BUILD_LAYERS := "${@kiosk_build_layers(d)}"
+WISEKIOSK_BUILD_LAYERS[vardepvalue] = "${WISEKIOSK_BUILD_LAYERS}"
+
+# Shell-sourceable KEY=VALUE, one fact per line. BUILD_INFO_VERSION so a later
+# format change is a detectable failure in tools/build-stamp-check.sh rather than
+# a silent parse difference.
+#
+# ROOTFS_POSTPROCESS_COMMAND, not IMAGE_PREPROCESS_COMMAND: this runs before
+# reproducible_final_image_task, so the new file's mtime gets the same clamp as
+# the rest of the rootfs.
+#
+# The heredoc delimiter is quoted -- bitbake expands ${...} in the function body
+# before the shell ever sees it, so quoting only stops bash re-expanding a value.
+#
+# EVERY value is quoted, including the ones that cannot contain a space. The
+# designed failure value is the literal <unknown>, and < > are redirection
+# operators: unquoted, `. /etc/build-info` dies with a syntax error, leaves the
+# field EMPTY rather than <unknown>, and abandons every later line in the file.
+# The one path built to be loud would read as "field absent". Quoting is what
+# keeps the shell-sourceable contract true on the failure path, which is the only
+# path where it matters. tools/build-stamp-check.sh strips the quotes in awk.
+kiosk_write_build_info() {
+    cat > ${IMAGE_ROOTFS}${sysconfdir}/build-info <<'EOF'
+BUILD_INFO_VERSION="1"
+META_WISEKIOSK_COMMIT="${WISEKIOSK_COMMIT}"
+META_WISEKIOSK_COMMIT_SHORT="${WISEKIOSK_COMMIT_SHORT}"
+META_WISEKIOSK_DIRTY="${WISEKIOSK_DIRTY}"
+META_WISEKIOSK_BRANCH="${WISEKIOSK_BRANCH}"
+BUILD_MACHINE="${MACHINE}"
+BUILD_DISTRO="${DISTRO}"
+BUILD_DISTRO_VERSION="${DISTRO_VERSION}"
+BUILD_LAYERS="${WISEKIOSK_BUILD_LAYERS}"
+EOF
+    chmod 0644 ${IMAGE_ROOTFS}${sysconfdir}/build-info
+}
+
+# No trailing semicolon, and this is load-bearing rather than style. The two
+# consumers of this variable disagree about the separator: oe.utils
+# execute_pre_post_process does cmds.replace(";", " ") before splitting, so
+# "kiosk_write_build_info;" RUNS; bitbake's dependency scanner does not, and
+# records the token verbatim as a name. "kiosk_write_build_info;" resolves to no
+# variable, so its body -- and every WISEKIOSK_* reference in it -- contributes
+# nothing to do_rootfs's hash. The stamp would then be written on the first build
+# and never again: the file exists, parses, and silently names whichever commit
+# was checked out when do_rootfs last ran, which is the exact stale-sha defect
+# issue #46 exists to prevent. Bare, the name resolves and WISEKIOSK_COMMIT lands
+# in do_rootfs's dependency list, which is what makes the sha bust the hash.
+#
+# The trap is class-wide, not specific to this class: any postprocess function
+# appended with a semicolon has an unhashed body, so editing what it does leaves
+# do_rootfs stamped and the previous output shipped. Guard 9 in tools/ci-guards.sh
+# rejects the form across every class here, because a comment saying "do not do
+# this" is a finding and not a mitigation.
+ROOTFS_POSTPROCESS_COMMAND += "kiosk_write_build_info"

--- a/meta-wisekiosk/classes/kiosk-buildstamp.bbclass
+++ b/meta-wisekiosk/classes/kiosk-buildstamp.bbclass
@@ -1,39 +1,8 @@
-# Bake this repository's commit into every image, at ${sysconfdir}/build-info.
+# Bake this repository's commit into every image, at ${sysconfdir}/build-info
+# (#46 image build stamp). Mechanism and rationale: docs/layers-and-kas.md.
 #
-# The three files that look like provenance are not: DISTRO_VERSION is the
-# hardcoded "0.1" upstream sets, /etc/os-release derives from it, and
-# /etc/version is the reproducible-build epoch clamp -- identical on every build
-# of every project. An image built today and one built in June are byte-identical
-# in all three, so a running slot cannot name the source it came from and an
-# investigation cannot attribute what it measured (issue #46).
-#
-# Why a postprocess and not a recipe: a package recipe running `git` inside
-# do_install produces a task hash bitbake cannot invalidate, sstate replays the
-# old .ipk, and every later image bakes the sha of whichever commit happened to
-# be checked out first -- a file that exists, parses, and is WRONG. The image
-# path cannot do that: rootfs_variables() (image.bbclass) puts
-# ROOTFS_POSTPROCESS_COMMAND in do_rootfs[vardeps], bitbake resolves each name in
-# it to a function and hashes that function's body and variable references, so
-# the values below reach the task hash -- see the separator note above
-# ROOTFS_POSTPROCESS_COMMAND, which is what makes that resolution happen. Image
-# tasks also carry SSTATE_SKIP_CREATION, so there is no cached artifact to replay
-# over a changed hash.
-#
-# The capture is in configuration space with := and a [vardepvalue], copying
-# metadata_scm.bbclass: without that flag bitbake hashes the expression text
-# rather than its value, and the sha would never move the hash.
-#
-# NOT recorded: build timestamp, builder hostname, builder username. The latter
-# two are the identifying detail guard 6 exists to keep out of a public
-# repository, arriving by a route no guard watches.
-#
-# The reproducibility unit is therefore commit + branch + dirty state, not commit
-# alone: BRANCH and DIRTY are baked and hashed, and neither is a function of the
-# commit. The same tree built on two branches, or built dirty and then clean,
-# yields different files and re-runs do_rootfs. Excluding a timestamp is what
-# keeps the unit that small -- a timestamp would make even a repeat build of one
-# commit on one branch differ. On a detached checkout `git rev-parse
-# --abbrev-ref HEAD` answers the literal `HEAD`, which is recorded as-is.
+# Not recorded: build timestamp, hostname, username -- reproducibility, and
+# guard 6 keeps identifying detail out of a public repository.
 
 def kiosk_layerdir(d):
     """This layer's path, from BBLAYERS.
@@ -69,10 +38,9 @@ def kiosk_git(d, cmd, cwd=None):
 def kiosk_commit(d):
     """The full sha of the repository this layer belongs to, or <unknown>.
 
-    <unknown>, not '', so the shipped file records that the build could not
-    attribute itself; tools/build-stamp-check.sh's 40-hex assertion is what turns
-    that into a red flash rather than a quiet wrong answer. Inside kas-container
-    the likely cause is git refusing the bind-mounted tree as dubiously owned.
+    <unknown>, not '', so the file records that the build could not attribute
+    itself; tools/build-stamp-check.sh's 40-hex assertion turns that into a
+    failure rather than a quiet wrong answer.
 
     git walks upward from the layer, so the answer is the PARENT repository's
     HEAD -- correct here, where bblayers.conf resolves the layer to a
@@ -93,21 +61,11 @@ def kiosk_commit(d):
 def kiosk_dirty(d):
     """1 if the working tree differs from the commit above, tracked or untracked.
 
-    Scoped to the whole repository, matching META_WISEKIOSK_COMMIT, which is the
-    repository's HEAD and not the layer's (owner, 2026-08-18). kiosk-zero-w.yaml,
-    includes/ and patches/ are build inputs living outside the layer, so a
-    layer-scoped flag would read 0 while an uncommitted edit to any of them moved
-    the image.
-
-    git status, not oe.buildcfg.is_layer_modified, which is `git diff` only: a
-    brand-new untracked .bb reads clean there, and BBFILES in conf/layer.conf
-    picks that file up, so it IS in the image. The cost is that a stray editor
-    swapfile flips the flag, which is the intended trade.
-
-    Recorded, never refused. A build that will not run on a dirty tree makes the
-    develop loop hostile; making the fact legible is the whole job, and an
-    investigation quoting META_WISEKIOSK_DIRTY=1 is already disqualified by its
-    own standard. An unreadable tree counts as dirty.
+    Repository-scoped, matching META_WISEKIOSK_COMMIT: kiosk-zero-w.yaml,
+    includes/ and patches/ are build inputs living outside the layer. git status,
+    not oe.buildcfg.is_layer_modified, which is `git diff` only and reads a new
+    untracked .bb as clean while BBFILES puts it in the image. An unreadable tree
+    counts as dirty. Dirty is reported, never refused (owner, 2026-08-18).
     """
     top = kiosk_git(d, 'git rev-parse --show-toplevel')
     if not top:
@@ -119,22 +77,19 @@ def kiosk_build_layers(d):
     """Every layer as name:shortsha, flattened onto one line.
 
     Informational -- the guard asserts META_WISEKIOSK_COMMIT only. It narrows,
-    and does not close, the gap that sources/ is gitignored: a hand-patched
-    upstream layer or a rotated signing key moves the image without moving this
-    repository's HEAD.
+    and does not close, the gap that sources/ is gitignored.
 
-    get_layer_revisions also offers a modified flag; it is dropped rather than
-    emitted. It is `git diff` (tracked only), so it would print a bare
-    meta-wisekiosk token -- read as "clean" -- for a tree META_WISEKIOSK_DIRTY
-    calls dirty. One file must not answer the same question two ways, and DIRTY
-    is the answer meant to be quoted. `path` is likewise discarded: it is the
-    builder's absolute path, and this file ships in a public image.
+    get_layer_revisions' modified flag is dropped: it is `git diff` only and
+    would contradict META_WISEKIOSK_DIRTY. `path` is dropped as the builder's
+    absolute path, and this file ships in a public image.
     """
     tokens = []
     for _path, name, _branch, rev, _modified in oe.buildcfg.get_layer_revisions(d):
         tokens.append('%s:%s' % (name, rev[:12]))
     return ' '.join(tokens)
 
+# := + [vardepvalue] (as metadata_scm.bbclass): hash the value, not the
+# expression.
 WISEKIOSK_COMMIT := "${@kiosk_commit(d)}"
 WISEKIOSK_COMMIT[vardepvalue] = "${WISEKIOSK_COMMIT}"
 # Sliced from the captured value rather than asked of git again, so the short sha
@@ -144,14 +99,13 @@ WISEKIOSK_COMMIT_SHORT := "${@d.getVar('WISEKIOSK_COMMIT')[:12]}"
 WISEKIOSK_COMMIT_SHORT[vardepvalue] = "${WISEKIOSK_COMMIT_SHORT}"
 WISEKIOSK_DIRTY := "${@kiosk_dirty(d)}"
 WISEKIOSK_DIRTY[vardepvalue] = "${WISEKIOSK_DIRTY}"
+# On a detached checkout git answers the literal `HEAD`, recorded as-is.
 WISEKIOSK_BRANCH := "${@kiosk_git(d, 'git rev-parse --abbrev-ref HEAD') or '<unknown>'}"
 WISEKIOSK_BRANCH[vardepvalue] = "${WISEKIOSK_BRANCH}"
 WISEKIOSK_BUILD_LAYERS := "${@kiosk_build_layers(d)}"
 WISEKIOSK_BUILD_LAYERS[vardepvalue] = "${WISEKIOSK_BUILD_LAYERS}"
 
-# Shell-sourceable KEY=VALUE, one fact per line. BUILD_INFO_VERSION so a later
-# format change is a detectable failure in tools/build-stamp-check.sh rather than
-# a silent parse difference.
+# Shell-sourceable KEY=VALUE; every value quoted (see docs/layers-and-kas.md).
 #
 # ROOTFS_POSTPROCESS_COMMAND, not IMAGE_PREPROCESS_COMMAND: this runs before
 # reproducible_final_image_task, so the new file's mtime gets the same clamp as
@@ -159,14 +113,6 @@ WISEKIOSK_BUILD_LAYERS[vardepvalue] = "${WISEKIOSK_BUILD_LAYERS}"
 #
 # The heredoc delimiter is quoted -- bitbake expands ${...} in the function body
 # before the shell ever sees it, so quoting only stops bash re-expanding a value.
-#
-# EVERY value is quoted, including the ones that cannot contain a space. The
-# designed failure value is the literal <unknown>, and < > are redirection
-# operators: unquoted, `. /etc/build-info` dies with a syntax error, leaves the
-# field EMPTY rather than <unknown>, and abandons every later line in the file.
-# The one path built to be loud would read as "field absent". Quoting is what
-# keeps the shell-sourceable contract true on the failure path, which is the only
-# path where it matters. tools/build-stamp-check.sh strips the quotes in awk.
 kiosk_write_build_info() {
     cat > ${IMAGE_ROOTFS}${sysconfdir}/build-info <<'EOF'
 BUILD_INFO_VERSION="1"
@@ -182,21 +128,7 @@ EOF
     chmod 0644 ${IMAGE_ROOTFS}${sysconfdir}/build-info
 }
 
-# No trailing semicolon, and this is load-bearing rather than style. The two
-# consumers of this variable disagree about the separator: oe.utils
-# execute_pre_post_process does cmds.replace(";", " ") before splitting, so
-# "kiosk_write_build_info;" RUNS; bitbake's dependency scanner does not, and
-# records the token verbatim as a name. "kiosk_write_build_info;" resolves to no
-# variable, so its body -- and every WISEKIOSK_* reference in it -- contributes
-# nothing to do_rootfs's hash. The stamp would then be written on the first build
-# and never again: the file exists, parses, and silently names whichever commit
-# was checked out when do_rootfs last ran, which is the exact stale-sha defect
-# issue #46 exists to prevent. Bare, the name resolves and WISEKIOSK_COMMIT lands
-# in do_rootfs's dependency list, which is what makes the sha bust the hash.
-#
-# The trap is class-wide, not specific to this class: any postprocess function
-# appended with a semicolon has an unhashed body, so editing what it does leaves
-# do_rootfs stamped and the previous output shipped. Guard 9 in tools/ci-guards.sh
-# rejects the form across every class here, because a comment saying "do not do
-# this" is a finding and not a mitigation.
+# Bare name, no trailing ';': a glued ';' is not a resolvable variable name, so
+# the body reaches no task hash. Enforced by guard 9 in tools/ci-guards.sh;
+# mechanism in docs/layers-and-kas.md.
 ROOTFS_POSTPROCESS_COMMAND += "kiosk_write_build_info"

--- a/meta-wisekiosk/classes/kiosk-static-resolv.bbclass
+++ b/meta-wisekiosk/classes/kiosk-static-resolv.bbclass
@@ -29,4 +29,9 @@ kiosk_set_static_resolv() {
     ln -s /data/config/resolv.conf ${IMAGE_ROOTFS}${sysconfdir}/resolv.conf
 }
 
-ROOTFS_POSTPROCESS_COMMAND += "kiosk_set_static_resolv;"
+# No trailing semicolon: a token carrying one is not a variable name, so bitbake
+# resolves it to nothing and this function's BODY reaches no task hash -- editing
+# what it symlinks would leave do_rootfs stamped and the old link shipped. See
+# kiosk-buildstamp.bbclass, which explains the two-parsers mechanism in full, and
+# guard 9 in tools/ci-guards.sh, which now rejects the semicolon form.
+ROOTFS_POSTPROCESS_COMMAND += "kiosk_set_static_resolv"

--- a/meta-wisekiosk/classes/kiosk-static-resolv.bbclass
+++ b/meta-wisekiosk/classes/kiosk-static-resolv.bbclass
@@ -29,9 +29,5 @@ kiosk_set_static_resolv() {
     ln -s /data/config/resolv.conf ${IMAGE_ROOTFS}${sysconfdir}/resolv.conf
 }
 
-# No trailing semicolon: a token carrying one is not a variable name, so bitbake
-# resolves it to nothing and this function's BODY reaches no task hash -- editing
-# what it symlinks would leave do_rootfs stamped and the old link shipped. See
-# kiosk-buildstamp.bbclass, which explains the two-parsers mechanism in full, and
-# guard 9 in tools/ci-guards.sh, which now rejects the semicolon form.
+# Bare name: a ';' glued to it hides this body from the task hash (guard 9).
 ROOTFS_POSTPROCESS_COMMAND += "kiosk_set_static_resolv"

--- a/tools/build-stamp-check.sh
+++ b/tools/build-stamp-check.sh
@@ -5,30 +5,8 @@
 #   tools/build-stamp-check.sh --require        -- ... and an unreadable one FAILS
 #   tools/build-stamp-check.sh [--require] <rootfs.ext4|rootfs-dir>
 #
-# Host-only, and deliberately NOT in tools/ci-guards.sh: CI never builds, so a
-# rootfs check there would be a required gate that skips on every run, which this
-# repository has already ruled against. Guard 9 is the half CI can see -- that
-# the wiring still exists. This is the half that reads the artifact.
-#
-# It reads the SHIPPED .ext4, not the unpacked rootfs tree, because the .ext4 is
-# what `just flash` writes and `just kiosk-bundle` packages; the tree is a
-# fallback for a `bitbake core-image-base` that never ran do_image.
-#
-# What it asserts, and why each one is load-bearing:
-#   BUILD_INFO_VERSION  -- a format change must fail here rather than become a
-#                          silent parse difference.
-#   40 lowercase hex    -- oe.buildcfg swallows every git failure and returns the
-#                          literal <unknown>; inside kas-container that is the
-#                          likely symptom of git refusing the bind-mounted tree
-#                          as dubiously owned. This is what turns a quiet wrong
-#                          answer into a red build.
-#   SHORT is a prefix   -- catches the two fields drifting apart.
-#   DIRTY is 0 or 1     -- one comparison on-device and here, not OE's
-#                          " -- modified" string.
-#
-# A dirty build is REPORTED, never refused (owner, 2026-08-18): refusing would
-# make the develop-and-test loop hostile, and an investigation quoting
-# META_WISEKIOSK_DIRTY=1 is already disqualified by its own standard.
+# Host-only: CI never builds, so this is not in tools/ci-guards.sh. Guard 9
+# checks the wiring; this reads the artifact. See docs/layers-and-kas.md.
 
 set -uo pipefail
 
@@ -47,17 +25,15 @@ for arg in "$@"; do
 done
 
 die()  { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
-# Loud, on stdout, exit 0. Silence here would be indistinguishable from a clean
-# run, which is the exact failure this script exists to prevent
-# (tools/doc-image.py:177-186).
+# Loud, on stdout, exit 0 -- see tools/doc-image.py.
 skip() {
     if [ "$require" -eq 1 ]; then die "$*"; fi
     printf 'SKIPPED: %s -- build stamp check did not run\n' "$*"
     exit 0
 }
 
-# Newest match, or empty. `-nt` follows symlinks, which matters: the .ext4 in
-# deploy/images is a symlink onto the build-stamped file.
+# Newest match, or empty. `-nt` follows symlinks: the .ext4 in deploy/images is
+# a symlink onto the build-stamped file.
 newest_of() {
     local best="" f
     for f in "$@"; do
@@ -68,15 +44,12 @@ newest_of() {
 }
 
 if [ -z "$target" ]; then
-    # Only the discovery path needs the repository root; an explicit target stays
-    # relative to the caller's cwd.
     cd "$(git rev-parse --show-toplevel)" || exit 2
     mapfile -t ext4s < <(compgen -G "$EXT4_GLOB")
     target=$(newest_of "${ext4s[@]+"${ext4s[@]}"}")
     if [ -z "$target" ]; then
-        # The rootfs directory's own mtime is clamped to the reproducible epoch,
-        # so the unclamped recipe workdir above it is what dates the build
-        # (tools/doc-image.py:83-90).
+        # The rootfs directory's mtime is epoch-clamped; the recipe workdir above
+        # it is what dates the build.
         mapfile -t trees < <(compgen -G "$ROOTFS_GLOB")
         parents=()
         for t in "${trees[@]+"${trees[@]}"}"; do parents+=("$(dirname "$t")"); done
@@ -92,8 +65,7 @@ if [ -d "$target" ]; then
     info=$(cat "$target/etc/build-info" 2>/dev/null)
 else
     # Refuse, never skip: an artifact that exists and cannot be read is not the
-    # same as no artifact, and `just flash` refuses on a missing debugfs for the
-    # same reason (justfiles/deploy.just:41).
+    # same as no artifact.
     command -v debugfs >/dev/null 2>&1 \
         || die "debugfs missing -- cannot read $target; install e2fsprogs"
     info=$(debugfs -R "cat /etc/build-info" "$target" 2>/dev/null)
@@ -102,9 +74,8 @@ info=$(printf '%s' "$info" | tr -d '\r')
 
 [ -n "$info" ] || die "no /etc/build-info in $target -- this image cannot name the commit it was built from (is INHERIT += \"kiosk-buildstamp\" still in kiosk-zero-w.yaml?)"
 
-# First KEY= line, unquoted. One awk, no pipeline: `sed | head -n1` under
-# pipefail returns head's SIGPIPE kill of sed, which is a trap not worth leaving
-# in a script whose whole job is refusing to report a false pass.
+# First KEY= line, unquoted. One awk, not `sed | head`: under pipefail that
+# returns head's SIGPIPE kill of sed.
 field() {
     awk -v k="$1" 'index($0, k "=") == 1 { sub(/^[^=]*=/, ""); gsub(/"/, ""); print; exit }' <<< "$info"
 }

--- a/tools/build-stamp-check.sh
+++ b/tools/build-stamp-check.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Does the built image name the commit it was built from?
+#
+#   tools/build-stamp-check.sh                  -- newest artifact under build/
+#   tools/build-stamp-check.sh --require        -- ... and an unreadable one FAILS
+#   tools/build-stamp-check.sh [--require] <rootfs.ext4|rootfs-dir>
+#
+# Host-only, and deliberately NOT in tools/ci-guards.sh: CI never builds, so a
+# rootfs check there would be a required gate that skips on every run, which this
+# repository has already ruled against. Guard 9 is the half CI can see -- that
+# the wiring still exists. This is the half that reads the artifact.
+#
+# It reads the SHIPPED .ext4, not the unpacked rootfs tree, because the .ext4 is
+# what `just flash` writes and `just kiosk-bundle` packages; the tree is a
+# fallback for a `bitbake core-image-base` that never ran do_image.
+#
+# What it asserts, and why each one is load-bearing:
+#   BUILD_INFO_VERSION  -- a format change must fail here rather than become a
+#                          silent parse difference.
+#   40 lowercase hex    -- oe.buildcfg swallows every git failure and returns the
+#                          literal <unknown>; inside kas-container that is the
+#                          likely symptom of git refusing the bind-mounted tree
+#                          as dubiously owned. This is what turns a quiet wrong
+#                          answer into a red build.
+#   SHORT is a prefix   -- catches the two fields drifting apart.
+#   DIRTY is 0 or 1     -- one comparison on-device and here, not OE's
+#                          " -- modified" string.
+#
+# A dirty build is REPORTED, never refused (owner, 2026-08-18): refusing would
+# make the develop-and-test loop hostile, and an investigation quoting
+# META_WISEKIOSK_DIRTY=1 is already disqualified by its own standard.
+
+set -uo pipefail
+
+EXT4_GLOB="build/tmp-*/deploy/images/*/core-image-base-*.rootfs.ext4"
+ROOTFS_GLOB="build/tmp-*/work/*/core-image-base/*/rootfs"
+
+require=0
+target=""
+for arg in "$@"; do
+    case "$arg" in
+        --require) require=1 ;;
+        -h|--help) sed -n '2,6p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        -*) printf 'unknown option: %s\n' "$arg" >&2; exit 2 ;;
+        *)  target=$arg ;;
+    esac
+done
+
+die()  { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+# Loud, on stdout, exit 0. Silence here would be indistinguishable from a clean
+# run, which is the exact failure this script exists to prevent
+# (tools/doc-image.py:177-186).
+skip() {
+    if [ "$require" -eq 1 ]; then die "$*"; fi
+    printf 'SKIPPED: %s -- build stamp check did not run\n' "$*"
+    exit 0
+}
+
+# Newest match, or empty. `-nt` follows symlinks, which matters: the .ext4 in
+# deploy/images is a symlink onto the build-stamped file.
+newest_of() {
+    local best="" f
+    for f in "$@"; do
+        [ -e "$f" ] || continue
+        if [ -z "$best" ] || [ "$f" -nt "$best" ]; then best=$f; fi
+    done
+    printf '%s' "$best"
+}
+
+if [ -z "$target" ]; then
+    # Only the discovery path needs the repository root; an explicit target stays
+    # relative to the caller's cwd.
+    cd "$(git rev-parse --show-toplevel)" || exit 2
+    mapfile -t ext4s < <(compgen -G "$EXT4_GLOB")
+    target=$(newest_of "${ext4s[@]+"${ext4s[@]}"}")
+    if [ -z "$target" ]; then
+        # The rootfs directory's own mtime is clamped to the reproducible epoch,
+        # so the unclamped recipe workdir above it is what dates the build
+        # (tools/doc-image.py:83-90).
+        mapfile -t trees < <(compgen -G "$ROOTFS_GLOB")
+        parents=()
+        for t in "${trees[@]+"${trees[@]}"}"; do parents+=("$(dirname "$t")"); done
+        newest_parent=$(newest_of "${parents[@]+"${parents[@]}"}")
+        [ -n "$newest_parent" ] && target="$newest_parent/rootfs"
+    fi
+    [ -n "$target" ] || skip "no built image under $EXT4_GLOB or $ROOTFS_GLOB"
+fi
+
+[ -e "$target" ] || die "no such image artifact: $target"
+
+if [ -d "$target" ]; then
+    info=$(cat "$target/etc/build-info" 2>/dev/null)
+else
+    # Refuse, never skip: an artifact that exists and cannot be read is not the
+    # same as no artifact, and `just flash` refuses on a missing debugfs for the
+    # same reason (justfiles/deploy.just:41).
+    command -v debugfs >/dev/null 2>&1 \
+        || die "debugfs missing -- cannot read $target; install e2fsprogs"
+    info=$(debugfs -R "cat /etc/build-info" "$target" 2>/dev/null)
+fi
+info=$(printf '%s' "$info" | tr -d '\r')
+
+[ -n "$info" ] || die "no /etc/build-info in $target -- this image cannot name the commit it was built from (is INHERIT += \"kiosk-buildstamp\" still in kiosk-zero-w.yaml?)"
+
+# First KEY= line, unquoted. One awk, no pipeline: `sed | head -n1` under
+# pipefail returns head's SIGPIPE kill of sed, which is a trap not worth leaving
+# in a script whose whole job is refusing to report a false pass.
+field() {
+    awk -v k="$1" 'index($0, k "=") == 1 { sub(/^[^=]*=/, ""); gsub(/"/, ""); print; exit }' <<< "$info"
+}
+
+version=$(field BUILD_INFO_VERSION)
+commit=$(field META_WISEKIOSK_COMMIT)
+short=$(field META_WISEKIOSK_COMMIT_SHORT)
+dirty=$(field META_WISEKIOSK_DIRTY)
+branch=$(field META_WISEKIOSK_BRANCH)
+
+[ "$version" = "1" ] \
+    || die "BUILD_INFO_VERSION is '${version:-<absent>}', this check knows 1 -- the format moved and the checker did not"
+
+[[ "$commit" =~ ^[0-9a-f]{40}$ ]] \
+    || die "META_WISEKIOSK_COMMIT is '${commit:-<absent>}', not a 40-character sha -- the build could not read its own git tree, so nothing in $target is attributable"
+
+[ "${#short}" -eq 12 ] && [ "$short" = "${commit:0:12}" ] \
+    || die "META_WISEKIOSK_COMMIT_SHORT is '${short:-<absent>}', not the first 12 characters of $commit"
+
+case "$dirty" in
+    0|1) ;;
+    *) die "META_WISEKIOSK_DIRTY is '${dirty:-<absent>}', not 0 or 1" ;;
+esac
+
+printf 'build stamp ok: %s  branch %s  dirty %s\n' "$short" "${branch:-<absent>}" "$dirty"
+printf '  source: %s\n' "$target"
+if [ "$dirty" = "1" ]; then
+    printf '  WARNING: built from a modified tree -- %s does not describe what shipped\n' "$commit"
+fi

--- a/tools/ci-guards.sh
+++ b/tools/ci-guards.sh
@@ -296,6 +296,110 @@ else
     fi
 fi
 
+# --- 9. the build stamp must stay wired into the image --------------------
+# Without /etc/build-info an image cannot name the source it was built from --
+# DISTRO_VERSION is a hardcoded constant, /etc/os-release derives from it, and
+# /etc/version is the reproducibility epoch clamp, so every build looks alike
+# (issue #46). This is the half CI can honestly see: CI never builds, so the
+# baked file itself is checked host-side by tools/build-stamp-check.sh.
+#
+# The realistic regression is not the class breaking, it is the INHERIT going
+# missing while kiosk-zero-w.yaml is trimmed -- after which every build still
+# succeeds and every image is silently unattributable. Paths are
+# existence-checked first, as 1b/3/7/8, so a rename cannot read green.
+stamp_class="meta-wisekiosk/classes/kiosk-buildstamp.bbclass"
+stamp_image="kiosk-zero-w.yaml"
+class_dir9="meta-wisekiosk/classes"
+missing9=""
+[ -f "$stamp_class" ] || missing9="$missing9 $stamp_class"
+[ -f "$stamp_image" ] || missing9="$missing9 $stamp_image"
+[ -d "$class_dir9" ]  || missing9="$missing9 $class_dir9"
+if [ -n "$missing9" ]; then
+    bad "guard 9 cannot scan -- path renamed or removed:$missing9"
+else
+    # grep -c and compare, never `| grep -q` -- pipefail inverts a match (see
+    # the note at guard 7). Comments are stripped first, so the path named in
+    # this class's own header cannot green the check.
+    #
+    # The assignment pattern mirrors guard 7's (:227): the optional [:_]... group
+    # admits :append, :remove, :append:pn-core-image-base and the legacy _append.
+    # All are legal and idiomatic -- OE's own documentation teaches the override
+    # form -- and a guard that rejected them would train the next editor to loosen
+    # it, which is how the checks that do work get weakened.
+    #
+    # The path check is deliberately "names it", not "cat-redirects into it": a
+    # rewrite to printf or a heredoc-free form is legal and must not false-FAIL.
+    # What it polices is the PATH, which docs/issue_investigation/TEMPLATE.md and
+    # README.md both quote; that the write happens at all is the postprocess hook
+    # above it, and that it produced something readable is
+    # tools/build-stamp-check.sh against the artifact.
+    assign9='^[[:space:]]*ROOTFS_POSTPROCESS_COMMAND([:_][A-Za-z0-9._:+-]+)?[[:space:]]*[?:+.]*='
+    body9=$(grep -vE '^[[:space:]]*#' "$stamp_class")
+    hooks9=$(grep -cE "$assign9" <<< "$body9")
+    writes9=$(grep -cE '\$\{sysconfdir\}/build-info' <<< "$body9")
+    inherit9=$(grep -vE '^[[:space:]]*#' "$stamp_image" \
+        | grep -cE '^[[:space:]]*INHERIT[[:space:]]*[?:+.]*=.*kiosk-buildstamp')
+
+    # A postprocess function appended with a semicolon GLUED to its name runs but
+    # is invisible to the task hash. image.bbclass installs the value of
+    # ROOTFS_POSTPROCESS_COMMAND as its own vardeps and bb/data.py splits that on
+    # whitespace, so "kiosk_write_build_info;" is looked up as a variable of that
+    # exact name, resolves to nothing, and contributes neither the function body
+    # nor the variables it references. oe/utils.py meanwhile does
+    # cmds.replace(";", " ") before executing, so it runs perfectly. Two consumers,
+    # one string, opposite parsers: the output is written once and then silently
+    # frozen while the source moves. That is the defect issue #46 shipped and this
+    # check exists to make un-shippable.
+    #
+    # Scanned across every file that can carry build wiring -- classes, recipes,
+    # bbappends and kiosk-zero-w.yaml's local_conf_header -- and across all four
+    # command variables image.bbclass feeds to rootfs_command_variables(), not
+    # just the one this class uses. The trap is a property of the variable, and
+    # the next editor copies whichever sibling file is open; widening the file set
+    # is cheaper than widening the parser.
+    #
+    # Backslash continuations are joined first, because the idiomatic OE form for
+    # a multi-command list puts the functions on their own lines and only the
+    # assignment line would otherwise be inspected. Joining cannot create a false
+    # FAIL: it can only lengthen the value actually assigned to one of these
+    # variables, and a ";" glued to a name anywhere in that value is the defect.
+    #
+    # Flagged when the ";" follows a name character or a "}" -- "${SOME_FUNC};"
+    # expands to a glued token too. NOT flagged after whitespace: OE's own
+    # "func ;" spaced form makes the ";" a separate token, which reaches no hash
+    # but takes nothing with it, and rejecting it would train the next editor to
+    # loosen the guard.
+    cmdvars9='(ROOTFS|IMAGE)_(PRE|POST)PROCESS_COMMAND'
+    semiassign9="^[[:space:]]*${cmdvars9}([:_][A-Za-z0-9._:+-]+)?[[:space:]]*[?:+.]*="
+    mapfile -t scan9 < <(
+        find "$class_dir9" -maxdepth 1 -name '*.bbclass' 2>/dev/null
+        find meta-wisekiosk \( -name '*.bb' -o -name '*.bbappend' \) 2>/dev/null
+        printf '%s\n' "$stamp_image"
+    )
+    semis9=""
+    for file9 in "${scan9[@]}"; do
+        [ -f "$file9" ] || continue
+        glued9=$(sed -e ':a' -e '/\\$/N; s/\\\n//; ta' "$file9" \
+            | grep -vE '^[[:space:]]*#' \
+            | grep -E "$semiassign9" \
+            | sed -E 's/^[^=]*=//; s/#.*//' \
+            | grep -cE '[A-Za-z0-9_}];')
+        [ "$glued9" -gt 0 ] && semis9="$semis9 $file9"
+    done
+
+    if [ "$hooks9" -eq 0 ]; then
+        bad "guard 9: $stamp_class hooks no rootfs postprocess -- nothing runs it"
+    elif [ "$writes9" -eq 0 ]; then
+        bad "guard 9: $stamp_class no longer names \${sysconfdir}/build-info -- README.md and docs/issue_investigation/TEMPLATE.md quote that path"
+    elif [ "$inherit9" -eq 0 ]; then
+        bad "guard 9: $stamp_image does not INHERIT kiosk-buildstamp -- images would ship unattributable"
+    elif [ -n "$semis9" ]; then
+        bad "guard 9: a rootfs/image *PROCESS_COMMAND names a function with a trailing ';' in:$semis9 -- that token reaches no task hash, so the function's output freezes while its inputs move (drop the ';', or space it off the name)"
+    else
+        ok "the build stamp is wired into the image"
+    fi
+fi
+
 if [ "$fail" -ne 0 ]; then
     printf '\nguards FAILED\n'
     exit 1

--- a/tools/ci-guards.sh
+++ b/tools/ci-guards.sh
@@ -297,104 +297,116 @@ else
 fi
 
 # --- 9. the build stamp must stay wired into the image --------------------
-# Without /etc/build-info an image cannot name the source it was built from --
-# DISTRO_VERSION is a hardcoded constant, /etc/os-release derives from it, and
-# /etc/version is the reproducibility epoch clamp, so every build looks alike
-# (issue #46). This is the half CI can honestly see: CI never builds, so the
-# baked file itself is checked host-side by tools/build-stamp-check.sh.
-#
-# The realistic regression is not the class breaking, it is the INHERIT going
-# missing while kiosk-zero-w.yaml is trimmed -- after which every build still
-# succeeds and every image is silently unattributable. Paths are
-# existence-checked first, as 1b/3/7/8, so a rename cannot read green.
+# Without /etc/build-info an image cannot name its source (#46 image build
+# stamp). CI never builds, so this checks the wiring; the mechanism is in
+# docs/layers-and-kas.md.
 stamp_class="meta-wisekiosk/classes/kiosk-buildstamp.bbclass"
 stamp_image="kiosk-zero-w.yaml"
+stamp_checker="tools/build-stamp-check.sh"
+stamp_callers9="justfiles/deploy.just justfiles/ota.just"
 class_dir9="meta-wisekiosk/classes"
 missing9=""
-[ -f "$stamp_class" ] || missing9="$missing9 $stamp_class"
-[ -f "$stamp_image" ] || missing9="$missing9 $stamp_image"
-[ -d "$class_dir9" ]  || missing9="$missing9 $class_dir9"
+[ -f "$stamp_class" ]   || missing9="$missing9 $stamp_class"
+[ -f "$stamp_image" ]   || missing9="$missing9 $stamp_image"
+[ -f "$stamp_checker" ] || missing9="$missing9 $stamp_checker"
+[ -d "$class_dir9" ]    || missing9="$missing9 $class_dir9"
+for file9 in $stamp_callers9; do
+    [ -f "$file9" ] || missing9="$missing9 $file9"
+done
 if [ -n "$missing9" ]; then
     bad "guard 9 cannot scan -- path renamed or removed:$missing9"
 else
     # grep -c and compare, never `| grep -q` -- pipefail inverts a match (see
-    # the note at guard 7). Comments are stripped first, so the path named in
-    # this class's own header cannot green the check.
+    # the note at guard 7).
     #
-    # The assignment pattern mirrors guard 7's (:227): the optional [:_]... group
-    # admits :append, :remove, :append:pn-core-image-base and the legacy _append.
-    # All are legal and idiomatic -- OE's own documentation teaches the override
-    # form -- and a guard that rejected them would train the next editor to loosen
-    # it, which is how the checks that do work get weakened.
-    #
-    # The path check is deliberately "names it", not "cat-redirects into it": a
-    # rewrite to printf or a heredoc-free form is legal and must not false-FAIL.
-    # What it polices is the PATH, which docs/issue_investigation/TEMPLATE.md and
-    # README.md both quote; that the write happens at all is the postprocess hook
-    # above it, and that it produced something readable is
-    # tools/build-stamp-check.sh against the artifact.
+    # The assignment pattern mirrors guard 7's: the optional [:_]... group admits
+    # :append, :remove, :append:pn-core-image-base and the legacy _append, all of
+    # which are legal and must not FAIL.
     assign9='^[[:space:]]*ROOTFS_POSTPROCESS_COMMAND([:_][A-Za-z0-9._:+-]+)?[[:space:]]*[?:+.]*='
     body9=$(grep -vE '^[[:space:]]*#' "$stamp_class")
     hooks9=$(grep -cE "$assign9" <<< "$body9")
-    writes9=$(grep -cE '\$\{sysconfdir\}/build-info' <<< "$body9")
+
+    # The path and key are looked for in the HOOKED FUNCTION'S BODY, taken by
+    # name from the assignment above, with comments stripped, so no comment or
+    # python docstring naming them can green a class whose write was deleted.
+    # Within that body the path is matched on its tail and the key on the name
+    # the checker parses: ${sysconfdir}/build-info and /etc/build-info are both
+    # legal spellings, as is a rewrite from the heredoc to printf.
+    #
+    # ';' is stripped with the quotes so a glued or spaced hook still resolves to
+    # a function name -- the semicolon branch below is what reports that defect.
+    hookfns9=$(grep -E "$assign9" <<< "$body9" \
+        | sed -E 's/^[^=]*=//; s/#.*//; s/[";\\]/ /g' \
+        | tr -s '[:space:]' '\n' \
+        | grep -E '^[A-Za-z_][A-Za-z0-9_]*$')
+    fnbody9=""
+    for fn9 in $hookfns9; do
+        fnbody9="$fnbody9
+$(sed -n "/^${fn9}[[:space:]]*()/,/^}/p" "$stamp_class" \
+    | grep -vE '^[[:space:]]*#' | sed -E 's/#.*//')"
+    done
+    writes9=$(grep -cE '/build-info' <<< "$fnbody9")
+    keys9=$(grep -cE 'META_WISEKIOSK_COMMIT=' <<< "$fnbody9")
     inherit9=$(grep -vE '^[[:space:]]*#' "$stamp_image" \
         | grep -cE '^[[:space:]]*INHERIT[[:space:]]*[?:+.]*=.*kiosk-buildstamp')
 
-    # A postprocess function appended with a semicolon GLUED to its name runs but
-    # is invisible to the task hash. image.bbclass installs the value of
-    # ROOTFS_POSTPROCESS_COMMAND as its own vardeps and bb/data.py splits that on
-    # whitespace, so "kiosk_write_build_info;" is looked up as a variable of that
-    # exact name, resolves to nothing, and contributes neither the function body
-    # nor the variables it references. oe/utils.py meanwhile does
-    # cmds.replace(";", " ") before executing, so it runs perfectly. Two consumers,
-    # one string, opposite parsers: the output is written once and then silently
-    # frozen while the source moves. That is the defect issue #46 shipped and this
-    # check exists to make un-shippable.
+    # README.md promises `just flash` and `just kiosk-preflight` REFUSE an
+    # artifact that cannot name its commit, and refusal comes only from
+    # --require: without it the checker prints SKIPPED and exits 0. So the flag
+    # is what is policed, not the mention -- comments are stripped whole-line and
+    # trailing, and continuations joined so a wrapped invocation still counts.
+    # Precedent: guard 8 on provision.sh.
+    unwired9=""
+    for file9 in $stamp_callers9; do
+        calls9=$(sed -e ':a' -e '/\\$/N; s/\\\n//; ta' "$file9" \
+            | grep -vE '^[[:space:]]*#' \
+            | sed -E 's/#.*//' \
+            | grep -cE 'build-stamp-check\.sh[^|&;]*--require')
+        [ "$calls9" -eq 0 ] && unwired9="$unwired9 $file9"
+    done
+
+    # A ';' glued to a function name in a *PROCESS_COMMAND runs (oe/utils.py
+    # replaces ';' with ' ') but reaches no task hash, freezing the output while
+    # its inputs move. Mechanism and scope: docs/layers-and-kas.md.
     #
-    # Scanned across every file that can carry build wiring -- classes, recipes,
-    # bbappends and kiosk-zero-w.yaml's local_conf_header -- and across all four
-    # command variables image.bbclass feeds to rootfs_command_variables(), not
-    # just the one this class uses. The trap is a property of the variable, and
-    # the next editor copies whichever sibling file is open; widening the file set
-    # is cheaper than widening the parser.
-    #
-    # Backslash continuations are joined first, because the idiomatic OE form for
-    # a multi-command list puts the functions on their own lines and only the
-    # assignment line would otherwise be inspected. Joining cannot create a false
-    # FAIL: it can only lengthen the value actually assigned to one of these
-    # variables, and a ";" glued to a name anywhere in that value is the defect.
-    #
-    # Flagged when the ";" follows a name character or a "}" -- "${SOME_FUNC};"
-    # expands to a glued token too. NOT flagged after whitespace: OE's own
-    # "func ;" spaced form makes the ";" a separate token, which reaches no hash
-    # but takes nothing with it, and rejecting it would train the next editor to
-    # loosen the guard.
-    cmdvars9='(ROOTFS|IMAGE)_(PRE|POST)PROCESS_COMMAND'
+    # Every OE command variable carries the trap, and every kas build input can
+    # carry an assignment. Continuations are joined so a multi-line list is
+    # inspected whole. The spaced "func ;" form is legal and not flagged.
+    cmdvars9='[A-Z][A-Z0-9_]*_(PRE|POST)[A-Z]*_COMMANDS?'
     semiassign9="^[[:space:]]*${cmdvars9}([:_][A-Za-z0-9._:+-]+)?[[:space:]]*[?:+.]*="
     mapfile -t scan9 < <(
         find "$class_dir9" -maxdepth 1 -name '*.bbclass' 2>/dev/null
-        find meta-wisekiosk \( -name '*.bb' -o -name '*.bbappend' \) 2>/dev/null
+        find meta-wisekiosk \( -name '*.bb' -o -name '*.bbappend' -o -name '*.inc' \) 2>/dev/null
+        find includes -name '*.yaml' 2>/dev/null
         printf '%s\n' "$stamp_image"
     )
     semis9=""
     for file9 in "${scan9[@]}"; do
         [ -f "$file9" ] || continue
-        glued9=$(sed -e ':a' -e '/\\$/N; s/\\\n//; ta' "$file9" \
+        assigns9=$(sed -e ':a' -e '/\\$/N; s/\\\n//; ta' "$file9" \
             | grep -vE '^[[:space:]]*#' \
-            | grep -E "$semiassign9" \
-            | sed -E 's/^[^=]*=//; s/#.*//' \
-            | grep -cE '[A-Za-z0-9_}];')
-        [ "$glued9" -gt 0 ] && semis9="$semis9 $file9"
+            | grep -E "$semiassign9")
+        while IFS= read -r line9; do
+            [ -n "$line9" ] || continue
+            value9=$(sed -E 's/^[^=]*=//; s/#.*//' <<< "$line9")
+            case "$value9" in
+                *[A-Za-z0-9_}]\;*)
+                    semis9="$semis9
+    $file9: $(sed -E 's/^[[:space:]]*//' <<< "$line9")" ;;
+            esac
+        done <<< "$assigns9"
     done
 
     if [ "$hooks9" -eq 0 ]; then
         bad "guard 9: $stamp_class hooks no rootfs postprocess -- nothing runs it"
-    elif [ "$writes9" -eq 0 ]; then
-        bad "guard 9: $stamp_class no longer names \${sysconfdir}/build-info -- README.md and docs/issue_investigation/TEMPLATE.md quote that path"
+    elif [ "$writes9" -eq 0 ] || [ "$keys9" -eq 0 ]; then
+        bad "guard 9: $stamp_class does not write META_WISEKIOSK_COMMIT to a build-info path -- README.md and docs/issue_investigation/TEMPLATE.md quote /etc/build-info"
+    elif [ -n "$unwired9" ]; then
+        bad "guard 9: $stamp_checker is not run with --require in:$unwired9 -- without the flag it prints SKIPPED and exits 0, while README.md promises those recipes refuse an unattributable artifact"
     elif [ "$inherit9" -eq 0 ]; then
         bad "guard 9: $stamp_image does not INHERIT kiosk-buildstamp -- images would ship unattributable"
     elif [ -n "$semis9" ]; then
-        bad "guard 9: a rootfs/image *PROCESS_COMMAND names a function with a trailing ';' in:$semis9 -- that token reaches no task hash, so the function's output freezes while its inputs move (drop the ';', or space it off the name)"
+        bad "guard 9: an OE *_(PRE|POST)*_COMMAND variable names a function with a trailing ';' -- that token reaches no task hash, so the function's output freezes while its inputs move (drop the ';', or space it off the name):$semis9"
     else
         ok "the build stamp is wired into the image"
     fi


### PR DESCRIPTION
## What
Bakes the `meta-wisekiosk` source commit into every image at `/etc/build-info`, making the issue-investigation template's mandatory board+commit field (rule R1) machine-verifiable. Closes #46.

## Mechanism
- `meta-wisekiosk/classes/kiosk-buildstamp.bbclass` captures the repo HEAD (40-hex + 12-char short), a whole-repo dirty flag (`git status --porcelain`, untracked counts, matching the commit's scope), branch, and a layer-revision table in configuration space (`:=` + `[vardepvalue]`), and writes shell-sourceable `KEY="value"` lines to `/etc/build-info` from `ROOTFS_POSTPROCESS_COMMAND`. Inherited globally via `kiosk-zero-w.yaml`.
- **Cache-safe by construction:** the values enter `do_rootfs`'s dependency hash and image tasks are never written to sstate, so the stamp moves with the commit. A commit-only change costs one `do_rootfs`+`do_image` — no package rebuilds, no WebKit.
- The file carries no timestamp, hostname or username (same-commit reproducibility + public-repo hygiene); on an A/B device `cat /etc/build-info` names the running slot's build.

## Verification — two parts, because CI never builds here
- **guard 9** (`tools/ci-guards.sh`, build-free, in CI): the stamp wiring is present, and no `(ROOTFS|IMAGE)_(PRE|POST)PROCESS_COMMAND` names a function with a trailing `;` — the hash-invisibility trap below — across the layer's classes, recipes and the kas config.
- **`build-stamp-check.sh`** (`just build-stamp`, host-only): reads the shipped `.ext4` with `debugfs`, asserts a 40-hex commit (rejecting the `<unknown>` git-failure fallback), a 12-char prefix and a `0|1` dirty flag. Wired fail-closed into `just flash` and `just kiosk-preflight`.

## Proven against a real containerised build
The first cut shipped a silent defect that a live build caught: a trailing semicolon in the postprocess wiring (`"kiosk_write_build_info;"`) let the function *run* but hid it from bitbake's dependency scanner, so `/etc/build-info` was written once and went stale — HEAD moved, 0 of 7250 tasks re-ran, and the image kept the old sha, right format and all. Fixed to the bare-name form (OE-core's own idiom) and now gated by guard 9 across the whole class, including the sibling `kiosk-static-resolv.bbclass` that carried the same latent form. Empirical proofs all pass: the sha lands (not `<unknown>`), moves on a new commit, and a same-commit rebuild is byte-stable.

## Known assumptions / follow-ups
- `just kiosk-preflight` verifies the image's stamp but **assumes** the bundle packages that rootfs — nothing binds them, and the filename tie can't (DATETIME is per-invocation). Documented as an explicit `# ASSUMPTION:` in `ota.just` and tracked as #48.
- `/etc/build-info` has not yet been read off a booted slot; that confirmation rides the #31 bench rerun, which needs a commit-stamped image anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJZ2dqzEUXUSMLWQE58ckE
