### PR TITLE
fix: a *_COMMAND that glues ';' to a function name ships nothing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,13 @@ secrets.yaml
 # Operator notes -- serials, MACs, addresses, readings -- which together
 # fingerprint one network, and local/keys, the RAUC key the fleet trusts. Both
 # must live in the tree, so NOT COMMITTING them is the whole protection.
+# Investigation working notes belong here too, beside the operator notes they
+# quote, and reach docs/issue_investigation/ only once they are written up.
 local/
+
+# Agent scratch space: drafts, seeded-defect fixtures, tool output. Untracked by
+# nature, and this repository is PUBLIC, so a stray `git add -A` publishes it.
+scratchpad/
 
 # The skills under .claude/ are tracked; these two are per-checkout machine
 # state, and settings.local.json in particular carries local filesystem paths.

--- a/Justfile
+++ b/Justfile
@@ -91,7 +91,7 @@ spotless: clean
 
 # Run the same checks CI runs. Fast, needs no build.
 [group('guards')]
-[doc("Run repository guards: secrets, template, shell syntax, YAML, gitleaks")]
+[doc("Run repository guards: secrets, template, shell syntax, YAML, gitleaks, IPs, service reachability, recovery wiring, trailing-; hooks")]
 guards:
     tools/ci-guards.sh
 

--- a/meta-wisekiosk/classes/kiosk-static-resolv.bbclass
+++ b/meta-wisekiosk/classes/kiosk-static-resolv.bbclass
@@ -29,4 +29,8 @@ kiosk_set_static_resolv() {
     ln -s /data/config/resolv.conf ${IMAGE_ROOTFS}${sysconfdir}/resolv.conf
 }
 
-ROOTFS_POSTPROCESS_COMMAND += "kiosk_set_static_resolv;"
+# Bare name, no trailing `;`: image.bbclass sets the raw value of this variable
+# as its own vardeps, and bitbake splits that on whitespace into names. A glued
+# `func;` is no name at all, so the function's body reaches no task hash and the
+# rootfs keeps whatever the first build wrote. Policed by guard 9.
+ROOTFS_POSTPROCESS_COMMAND += "kiosk_set_static_resolv"

--- a/meta-wisekiosk/classes/kiosk-static-resolv.bbclass
+++ b/meta-wisekiosk/classes/kiosk-static-resolv.bbclass
@@ -32,5 +32,6 @@ kiosk_set_static_resolv() {
 # Bare name, no trailing `;`: image.bbclass sets the raw value of this variable
 # as its own vardeps, and bitbake splits that on whitespace into names. A glued
 # `func;` is no name at all, so the function's body reaches no task hash and the
-# rootfs keeps whatever the first build wrote. Policed by guard 9.
+# rootfs keeps whatever the first build wrote. Policed by the trailing-`;` scan
+# in tools/ci-guards.sh.
 ROOTFS_POSTPROCESS_COMMAND += "kiosk_set_static_resolv"

--- a/tools/ci-guards.sh
+++ b/tools/ci-guards.sh
@@ -296,6 +296,62 @@ else
     fi
 fi
 
+# --- 9. no *_COMMAND may glue a `;` to a function name ---------------------
+# image.bbclass does `d.setVarFlag(var, 'vardeps', d.getVar(var))` over every
+# rootfs/image command variable, and bitbake splits a vardeps value on
+# WHITESPACE into names. `func;` is no name at all, so the function's body never
+# reaches the task hash: edit the function and bitbake replays the sstate rootfs,
+# and the change silently does not ship. oe.utils strips the `;` and runs it
+# either way, so the build succeeds and the form looks correct.
+#
+# `func ;` is legal and NOT flagged -- it splits into `func` and `;`, and `func`
+# is a name. The fix is to drop the character, never to restructure.
+#
+# Scanned over every file bitbake or kas reads here, not just the class that had
+# the bug: nothing about the glued form looks wrong at review, and the only
+# other way to notice it is a rebuild that does not change. Continuations are
+# joined first -- a multi-line command list is the shape most likely to carry
+# one. Paths are existence-checked, as 1b/3/7/8, so a rename cannot read green.
+scan9="meta-wisekiosk includes kiosk-zero-w.yaml"
+missing9=""
+for p in $scan9; do [ -e "$p" ] || missing9="$missing9 $p"; done
+if [ -n "$missing9" ]; then
+    bad "guard 9 cannot scan -- path renamed or removed:$missing9"
+else
+    files9=$( { find meta-wisekiosk -type f \
+                    \( -name '*.bbclass' -o -name '*.bb' -o -name '*.bbappend' -o -name '*.inc' \)
+                find includes -type f \( -name '*.yaml' -o -name '*.yml' \)
+                printf '%s\n' kiosk-zero-w.yaml; } 2>/dev/null | sort -u )
+    if [ -z "$files9" ]; then
+        bad "guard 9 found no bitbake or kas files to scan -- glob broken or layer renamed"
+    else
+        # A whole-line `#` is skipped so a quoted example cannot fail the guard;
+        # mid-line text is NOT stripped, because `#` inside a bitbake string is
+        # literal and stripping it would hide a real hit.
+        hits9=$(
+            while IFS= read -r f; do
+                [ -f "$f" ] || continue
+                awk -v F="$f" '
+                    { if (line == "" && $0 ~ /^[[:space:]]*#/) next
+                      if (line == "") start = NR
+                      line = line $0
+                      if (line ~ /\\$/) { sub(/\\$/, " ", line); next }
+                      if (line ~ /^[[:space:]]*[A-Z][A-Z0-9_]*_(PRE|POST)[A-Z_]*COMMANDS?([:_][A-Za-z0-9._:+-]+)?[[:space:]]*[?:+.]*=/ \
+                          && line ~ /[A-Za-z0-9_];/)
+                          printf "%s:%d: %s\n", F, start, line
+                      line = "" }
+                ' "$f"
+            done <<< "$files9"
+        )
+        if [ -n "$hits9" ]; then
+            bad "a *_COMMAND glues ';' to a function name -- its body reaches no task hash:"
+            printf '%s\n' "$hits9" | sed 's/^/        /'
+        else
+            ok "no *_COMMAND glues ';' to a function name"
+        fi
+    fi
+fi
+
 if [ "$fail" -ne 0 ]; then
     printf '\nguards FAILED\n'
     exit 1

--- a/tools/ci-guards.sh
+++ b/tools/ci-guards.sh
@@ -307,40 +307,63 @@ fi
 # `func ;` is legal and NOT flagged -- it splits into `func` and `;`, and `func`
 # is a name. The fix is to drop the character, never to restructure.
 #
+# `${VAR};` and `"…";` are caught too, not just a bare name: the trap is the
+# character, whatever precedes it.
+#
 # Scanned over every file bitbake or kas reads here, not just the class that had
-# the bug: nothing about the glued form looks wrong at review, and the only
-# other way to notice it is a rebuild that does not change. Continuations are
-# joined first -- a multi-line command list is the shape most likely to carry
-# one. Paths are existence-checked, as 1b/3/7/8, so a rename cannot read green.
-scan9="meta-wisekiosk includes kiosk-zero-w.yaml"
+# the bug: the layer's .bbclass/.bb/.bbappend/.inc/.conf, includes/*.yaml,
+# kiosk-zero-w.yaml, and patches/ (added lines only). Nothing about the glued
+# form looks wrong at review, and the only other way to notice it is a rebuild
+# that does not change. Continuations are joined first -- a multi-line command
+# list is the shape most likely to carry one. Paths are existence-checked, as
+# 1b/3/7/8, so a rename cannot read green.
+scan9="meta-wisekiosk includes kiosk-zero-w.yaml patches"
 missing9=""
 for p in $scan9; do [ -e "$p" ] || missing9="$missing9 $p"; done
 if [ -n "$missing9" ]; then
     bad "guard 9 cannot scan -- path renamed or removed:$missing9"
 else
-    files9=$( { find meta-wisekiosk -type f \
-                    \( -name '*.bbclass' -o -name '*.bb' -o -name '*.bbappend' -o -name '*.inc' \)
-                find includes -type f \( -name '*.yaml' -o -name '*.yml' \)
-                printf '%s\n' kiosk-zero-w.yaml; } 2>/dev/null | sort -u )
-    if [ -z "$files9" ]; then
-        bad "guard 9 found no bitbake or kas files to scan -- glob broken or layer renamed"
+    # The LAYER's own files are counted separately, as guard 7 does. Combining
+    # them with the kas config first would keep the list non-empty forever --
+    # `printf kiosk-zero-w.yaml` always emits -- so a broken layer glob or a
+    # renamed layer would read green with nothing actually scanned.
+    layer9=$(find meta-wisekiosk -type f \
+                 \( -name '*.bbclass' -o -name '*.bb' -o -name '*.bbappend' \
+                    -o -name '*.inc' -o -name '*.conf' \) 2>/dev/null | sort -u)
+    if [ -z "$layer9" ]; then
+        bad "guard 9 found no bitbake files under meta-wisekiosk -- glob broken or layer renamed"
     else
+        files9=$( { printf '%s\n' "$layer9"
+                    find includes -type f \( -name '*.yaml' -o -name '*.yml' \)
+                    printf '%s\n' kiosk-zero-w.yaml
+                    find patches -type f -name '*.patch'; } 2>/dev/null | sort -u )
         # A whole-line `#` is skipped so a quoted example cannot fail the guard;
         # mid-line text is NOT stripped, because `#` inside a bitbake string is
         # literal and stripping it would hide a real hit.
         hits9=$(
             while IFS= read -r f; do
                 [ -f "$f" ] || continue
-                awk -v F="$f" '
+                # A patch is a build input like any other (guard 1b's reason):
+                # it is applied to the meta-autonomos checkout before bitbake
+                # parses it, so it is a route to reintroduce the glued form.
+                # ADDED lines only -- a context line is upstream's existing
+                # content and a removed line is the defect going away. Non-added
+                # lines are BLANKED rather than dropped, so reported line numbers
+                # still point into the patch.
+                case "$f" in
+                    patches/*) src9=$(sed -e '/^+/!s/.*//' -e 's/^+//' "$f") ;;
+                    *)         src9=$(cat "$f") ;;
+                esac
+                awk -v F="$f" -v SEMI='[A-Za-z0-9_}"'"'"'];' '
                     { if (line == "" && $0 ~ /^[[:space:]]*#/) next
                       if (line == "") start = NR
                       line = line $0
                       if (line ~ /\\$/) { sub(/\\$/, " ", line); next }
                       if (line ~ /^[[:space:]]*[A-Z][A-Z0-9_]*_(PRE|POST)[A-Z_]*COMMANDS?([:_][A-Za-z0-9._:+-]+)?[[:space:]]*[?:+.]*=/ \
-                          && line ~ /[A-Za-z0-9_];/)
+                          && line ~ SEMI)
                           printf "%s:%d: %s\n", F, start, line
                       line = "" }
-                ' "$f"
+                ' <<< "$src9"
             done <<< "$files9"
         )
         if [ -n "$hits9" ]; then


### PR DESCRIPTION
A latent task-hash bug on `main`, plus the guard that keeps it from coming back.
Closes no issue and stands on its own.

## The bug

`meta-wisekiosk/classes/kiosk-static-resolv.bbclass` ended with

```
ROOTFS_POSTPROCESS_COMMAND += "kiosk_set_static_resolv;"
```

`image.bbclass` does `d.setVarFlag(var, 'vardeps', d.getVar(var))` over every
rootfs/image command variable
([`sources/poky/meta/classes-recipe/image.bbclass:130`]), and bitbake splits a
`vardeps` value on **whitespace** into names. `kiosk_set_static_resolv;` is not
a name, so the function's body reached no task hash. Editing the function left
the hash unchanged and bitbake replayed the sstate rootfs — the image kept
whatever the first build wrote.

`oe.utils` strips the `;` before running the function, so every build succeeded.
The only symptom is a rebuild that does not change what shipped.

`func ;` — spaced — is fine: it splits into `func` and `;`, and `func` is a name.
The fix is to drop the character.

## Guard 9

`tools/ci-guards.sh` gains a scan for the glued form over every
`*_(PRE|POST)*_COMMAND(S)` assignment — `ROOTFS_`, `IMAGE_`, `SDK_`,
`POPULATE_SDK_`, `OPKG_`, `RPM_`, `DEB_`, with any `:append` / override /
legacy `_append` suffix — across the layer's classes, recipes and bbappends,
`includes/`, and `kiosk-zero-w.yaml`. Line continuations are joined first: a
multi-line command list is the shape most likely to carry one. Paths are
existence-checked as guards 1b/3/7/8 do, so a rename fails rather than reading
green.

## Verification

`tools/ci-guards.sh` was run the way CI runs it, once per seeded case, with the
seed confirmed to have landed before each run:

| seeded | expected | got |
|---|---|---|
| `"kiosk_set_static_resolv;"` (the original defect) | FAIL | FAIL |
| `"kiosk_set_static_resolv"` (the fix) | pass | pass |
| `"kiosk_set_static_resolv ;"` (legal spaced form) | pass | pass |
| `ROOTFS_POSTPROCESS_COMMAND_append`, glued | FAIL | FAIL |
| `ROOTFS_POSTPROCESS_COMMAND:append`, glued | FAIL | FAIL |
| `IMAGE_PREPROCESS_COMMAND`, glued | FAIL | FAIL |
| `POPULATE_SDK_PRE_TARGET_COMMAND`, glued | FAIL | FAIL |
| a whole-line comment quoting the defect | pass | pass |
| glued across a line continuation | FAIL | FAIL |
| glued in `kiosk-zero-w.yaml` | FAIL | FAIL |
| glued in `includes/base.yaml` | FAIL | FAIL |
| glued in a `.bbappend` | FAIL | FAIL |

The last four exist to prove each scan path is live rather than silently empty.
Every other guard was re-run green after the change.

Not verified: no Yocto build was run, so the sstate-replay behaviour is argued
from `image.bbclass` and bitbake's `vardeps` semantics, not measured.

## Also

`.gitignore` gains `scratchpad/` — agent scratch space in a public repo.