### PR TITLE
ci: add CodeQL, Dependabot, shellcheck + actionlint

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -16,9 +16,11 @@ rc=0
 # optional. Chain to it explicitly so our hooks do not silently drop that
 # guarantee. If it is armed and missing, that is itself a failure, not a skip.
 global_dir=$(git config --global core.hooksPath 2>/dev/null)
+# \~ , not "~": a case pattern is tilde-expanded, so the tilde is escaped to
+# match the literal character git stored.
 case "$global_dir" in
-    "~/"*) global_dir="$HOME/${global_dir#\~/}" ;;
-    "~")   global_dir="$HOME" ;;
+    \~/*) global_dir="$HOME/${global_dir#\~/}" ;;
+    \~)   global_dir="$HOME" ;;
 esac
 if [ -n "$global_dir" ]; then
     if [ -x "$global_dir/pre-commit" ]; then

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,9 @@
 version: 2
 
 # Dependabot covers only the dependency surfaces GitHub can parse from a
-# manifest: the Actions this repo's workflows call, and the pip toolchain in
-# pyproject.toml. It does NOT and cannot manage the Yocto layer pins that
+# manifest: the Actions this repo's workflows call, and the uv-managed Python
+# toolchain (uv.lock + pyproject.toml). It does NOT and cannot manage the Yocto
+# layer pins that
 # actually build the image -- poky, meta-openembedded, meta-arm, meta-autonomos
 # and their SRCREVs live as git revisions in includes/base.yaml and are updated
 # by hand against upstream, because kas/BitBake pinning is invisible to it. A
@@ -27,7 +28,9 @@ updates:
           - minor
           - patch
 
-  - package-ecosystem: pip
+  # uv, not pip: this project is uv-managed (uv.lock is the source of truth);
+  # the pip ecosystem would update pyproject.toml but never the lockfile.
+  - package-ecosystem: uv
     directory: /
     schedule:
       interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+version: 2
+
+# Dependabot covers only the dependency surfaces GitHub can parse from a
+# manifest: the Actions this repo's workflows call, and the pip toolchain in
+# pyproject.toml. It does NOT and cannot manage the Yocto layer pins that
+# actually build the image -- poky, meta-openembedded, meta-arm, meta-autonomos
+# and their SRCREVs live as git revisions in includes/base.yaml and are updated
+# by hand against upstream, because kas/BitBake pinning is invisible to it. A
+# green Dependabot here is not a claim that the build inputs are current.
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: ci
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      # Batch the routine bumps into one reviewable PR; let a major (a
+      # potentially breaking action upgrade) arrive on its own.
+      actions-minor:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build
+    labels:
+      - dependencies
+      - python
+    groups:
+      python-minor:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,51 @@
+name: codeql
+
+# CodeQL analyses the languages GitHub can parse from source: this repo's own
+# Python tooling and the GitHub Actions workflows themselves (script injection,
+# unpinned actions, over-broad tokens). It does NOT see shell -- most of this
+# repo's logic and its whole flash/ssh/dd surface -- which lint.yml (shellcheck)
+# covers instead; nor the built image's packages, which BitBake's cve-check
+# would cover. A green run here is a statement about the scaffolding, not the
+# appliance.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, so a newly-published query catches code that has not changed.
+    - cron: "0 7 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - python
+          - actions
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # security-extended: broader security pack, chosen because the point
+          # of this workflow is hardening, not the lightest triage load.
+          queries: security-extended
+
+      # python and actions are no-build languages -- no autobuild/compile step.
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,9 +25,11 @@ jobs:
           # whose shebang invokes sh/bash (e.g. .githooks/pre-commit, which has
           # no extension). Justfile [script('bash')] bodies are embedded in
           # .just files and are not lintable here -- a known blind spot.
+          # docs/issue_investigation/ is excluded on purpose, not by oversight:
+          # those are frozen record-of-record scripts, exactly as they were run.
           shebang() {
             local f line
-            git ls-files | while IFS= read -r f; do
+            git ls-files -- ':!:docs/issue_investigation/**' | while IFS= read -r f; do
               [ -f "$f" ] || continue
               line=$(head -n1 -- "$f" 2>/dev/null || true)
               case "$line" in
@@ -35,13 +37,12 @@ jobs:
               esac
             done
           }
-          mapfile -t files < <( { git ls-files -- '*.sh' '*.bash'; shebang; } | sort -u | sed '/^$/d')
+          mapfile -t files < <( { git ls-files -- '*.sh' '*.bash' ':!:docs/issue_investigation/**'; shebang; } | sort -u | sed '/^$/d')
           if [ "${#files[@]}" -eq 0 ]; then
             echo "No shell scripts found -- failing rather than passing empty."; exit 1
           fi
           printf 'Linting %d files:\n' "${#files[@]}"; printf '  %s\n' "${files[@]}"
-          # SC1091: sourced files that are not present in the CI checkout.
-          shellcheck -x -e SC1091 -- "${files[@]}"
+          shellcheck -x -- "${files[@]}"
 
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,63 @@
+name: lint
+
+# Static analysis for the surfaces CodeQL cannot see: the shell scripts (which
+# are most of this repo -- provisioning, OTA, flashing, the guards themselves)
+# and the workflow files. Neither needs a Yocto build, so both can gate a PR.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: shellcheck
+        run: |
+          set -euo pipefail
+          shellcheck --version   # preinstalled on ubuntu-latest runners
+          # Every tracked shell script: *.sh/*.bash by extension, plus any file
+          # whose shebang invokes sh/bash (e.g. .githooks/pre-commit, which has
+          # no extension). Justfile [script('bash')] bodies are embedded in
+          # .just files and are not lintable here -- a known blind spot.
+          shebang() {
+            local f line
+            git ls-files | while IFS= read -r f; do
+              [ -f "$f" ] || continue
+              line=$(head -n1 -- "$f" 2>/dev/null || true)
+              case "$line" in
+                '#!'*sh|'#!'*sh\ *) printf '%s\n' "$f" ;;
+              esac
+            done
+          }
+          mapfile -t files < <( { git ls-files -- '*.sh' '*.bash'; shebang; } | sort -u | sed '/^$/d')
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No shell scripts found -- failing rather than passing empty."; exit 1
+          fi
+          printf 'Linting %d files:\n' "${#files[@]}"; printf '  %s\n' "${files[@]}"
+          # SC1091: sourced files that are not present in the CI checkout.
+          shellcheck -x -e SC1091 -- "${files[@]}"
+
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install actionlint
+        run: |
+          set -euo pipefail
+          VER=1.7.7
+          curl -sSfL "https://github.com/rhysd/actionlint/releases/download/v${VER}/actionlint_${VER}_linux_amd64.tar.gz" -o /tmp/actionlint.tgz
+          sudo tar -xzf /tmp/actionlint.tgz -C /usr/local/bin actionlint
+          actionlint -version
+
+      - name: Run actionlint
+        # actionlint also runs shellcheck over each workflow's run: blocks
+        # (shellcheck is preinstalled), so the inline shell in every workflow is
+        # linted too, not just the standalone scripts above.
+        run: actionlint -color

--- a/meta-wisekiosk/recipes-core/kiosk-bootprof/files/measure-surf.sh
+++ b/meta-wisekiosk/recipes-core/kiosk-bootprof/files/measure-surf.sh
@@ -30,7 +30,7 @@ NOW=$(cut -d. -f1 /proc/uptime)
 # xwininfo -tree, not -children: surf sets override-redirect, so the window is
 # absent from the client list and is not a direct child of root either.
 TITLE=''
-for try in 1 2 3 4 5; do
+for _ in 1 2 3 4 5; do
 	for id in $(xwininfo -root -tree 2>/dev/null | awk '/^ +0x/ { print $1 }'); do
 		t=$(xprop -id "$id" WM_NAME 2>/dev/null | sed 's/^WM_NAME(STRING) = "//; s/"$//')
 		case "$t" in *'| T '*) TITLE="$t" ;; esac

--- a/meta-wisekiosk/recipes-core/kiosk-netcheck/files/kiosk-netcheck
+++ b/meta-wisekiosk/recipes-core/kiosk-netcheck/files/kiosk-netcheck
@@ -16,9 +16,15 @@ DEADLINE=120
 IFACE=wlan0
 TARGET=
 
-# Test and site overrides. /data survives both an OTA and a slot reflash.
+# Test and site overrides. /data survives both an OTA and a slot reflash. The
+# .example beside this script documents that file's format, and is what the
+# linter follows below to see DEADLINE/IFACE/TARGET assigned from a source.
 CONF=/data/kiosk-netcheck.conf
 if [ -r "$CONF" ]; then
+    # SCRIPTDIR, so the name resolves from any working directory, not just the
+    # repository root.
+    # shellcheck source-path=SCRIPTDIR
+    # shellcheck source=kiosk-netcheck.conf.example
     . "$CONF"
 fi
 
@@ -54,6 +60,9 @@ eval "$(rauc status --output-format=shell)"
 
 fallback=
 for i in $RAUC_SLOTS; do
+    # Cleared per slot: each eval below re-assigns, and an empty value can never
+    # match "booted"/"good", so a slot missing a field cannot inherit the last.
+    state='' status='' bootname=''
     eval "state=\$RAUC_SLOT_STATE_$i"
     eval "status=\$RAUC_SLOT_BOOT_STATUS_$i"
     eval "bootname=\$RAUC_SLOT_BOOTNAME_$i"

--- a/meta-wisekiosk/recipes-core/kiosk-netcheck/files/kiosk-netcheck.conf.example
+++ b/meta-wisekiosk/recipes-core/kiosk-netcheck/files/kiosk-netcheck.conf.example
@@ -1,0 +1,28 @@
+# Example of /data/kiosk-netcheck.conf -- the site and test override file that
+# kiosk-netcheck sources at runtime. This file is NOT installed and NOT read on a
+# device: it documents the format, and it is what the source directive in
+# kiosk-netcheck points the linter at, so the three assignments the real file is
+# allowed to make are visible to static analysis.
+#
+# It carries no shebang and a .example name deliberately: both are what keep it
+# out of the shellcheck script set as a script in its own right.
+#
+# The real file lives on /data, which survives both an OTA and a slot reflash, so
+# an override set there outlives every update. It is sourced by a /bin/sh script:
+# plain NAME=value assignments only, no logic.
+#
+# Every value below is the script's own default, used here as a PLACEHOLDER.
+# Nothing site-specific belongs in this repository -- it is public.
+
+# Seconds to wait for a usable LAN before good-marking is withheld.
+DEADLINE=120
+
+# Interface whose default route names the gateway to ping.
+IFACE=wlan0
+
+# Ping this host instead of the interface's default gateway. Empty is the normal
+# case and means "take the gateway from the route table". Pointing it at an
+# unroutable address is how the no-LAN branch is exercised on the bench: it fails
+# the check while the real network stays up, so the lifeline into the board is
+# never the thing under test.
+TARGET=

--- a/tools/ci-guards.sh
+++ b/tools/ci-guards.sh
@@ -9,7 +9,7 @@
 # Run by hand:  tools/ci-guards.sh
 
 set -uo pipefail
-cd "$(git rev-parse --show-toplevel)"
+cd "$(git rev-parse --show-toplevel)" || exit 1
 
 fail=0
 bad() { printf 'FAIL  %s\n' "$*"; fail=1; }
@@ -47,16 +47,16 @@ fi
 # The paths are checked for existence first. grep over a path that no longer
 # exists reports nothing and this guard would read green, which is how a layer
 # rename silently disarms it.
-scan1b="kiosk-zero-w.yaml meta-wisekiosk includes patches"
+scan1b=(kiosk-zero-w.yaml meta-wisekiosk includes patches)
 missing1b=""
-for p in $scan1b; do
+for p in "${scan1b[@]}"; do
     [ -e "$p" ] || missing1b="$missing1b $p"
 done
 if [ -n "$missing1b" ]; then
     bad "guard 1b cannot scan -- path renamed or removed:$missing1b"
 fi
 sitevals=$(grep -rnE '\$\{(WIFI_SSID|WIFI_PSK_HASH|KIOSK_URL|KIOSK_HOSTNAME|KIOSK_MACHINE_ID|KIOSK_NAMESERVER)\}' \
-    $scan1b 2>/dev/null \
+    "${scan1b[@]}" 2>/dev/null \
     | grep -vE ':[[:space:]]*#' \
     | grep -vE '^patches/[^:]+:[0-9]+:-')
 if [ -n "$sitevals" ]; then
@@ -92,13 +92,13 @@ fi
 # them; the existence check keeps a rename from silently shrinking the scan,
 # same as guard 1b. The pre-commit hook is in that set: it is the thing that
 # runs this script, so a syntax error in it disarms every guard here.
-scan3="meta-wisekiosk/recipes-core/kiosk-netcheck/files/kiosk-netcheck \
-       meta-wisekiosk/recipes-core/kiosk-provision/files/kiosk-provision \
-       meta-wisekiosk/recipes-core/kiosk-recover/files/kiosk-recover \
-       meta-wisekiosk/recipes-core/kiosk-session/files/kiosk-launch \
-       .githooks/pre-commit"
+scan3=(meta-wisekiosk/recipes-core/kiosk-netcheck/files/kiosk-netcheck
+       meta-wisekiosk/recipes-core/kiosk-provision/files/kiosk-provision
+       meta-wisekiosk/recipes-core/kiosk-recover/files/kiosk-recover
+       meta-wisekiosk/recipes-core/kiosk-session/files/kiosk-launch
+       .githooks/pre-commit)
 missing3=""
-for p in $scan3; do [ -e "$p" ] || missing3="$missing3 $p"; done
+for p in "${scan3[@]}"; do [ -e "$p" ] || missing3="$missing3 $p"; done
 [ -n "$missing3" ] && bad "guard 3 cannot scan -- path renamed or removed:$missing3"
 badsh=0
 while IFS= read -r f; do
@@ -108,7 +108,7 @@ while IFS= read -r f; do
         printf '%s\n' "$err" | sed 's/^/        /'
         badsh=1
     fi
-done < <(git ls-files -- '*.sh' $scan3)
+done < <(git ls-files -- '*.sh' "${scan3[@]}")
 [ "$badsh" -eq 0 ] && ok "shell scripts parse"
 
 # --- 4. kas configs must be valid YAML ------------------------------------
@@ -142,9 +142,9 @@ if command -v gitleaks > /dev/null; then
     # Explicit --config: gitleaks does discover .gitleaks.toml on its own, but a
     # silently-unfound allowlist would fail the known finding on every run, and
     # a check that is always red gates nothing.
-    glargs=""
-    [ -f .gitleaks.toml ] && glargs="--config .gitleaks.toml"
-    if gitleaks detect $glargs --no-banner --redact --exit-code 1; then
+    glargs=()
+    [ -f .gitleaks.toml ] && glargs=(--config .gitleaks.toml)
+    if gitleaks detect "${glargs[@]}" --no-banner --redact --exit-code 1; then
         ok "gitleaks found no leaks"
     else
         bad "gitleaks reported findings"

--- a/tools/kiosk-bootprofile.sh
+++ b/tools/kiosk-bootprofile.sh
@@ -38,6 +38,9 @@ WAIT=${3:-180}
 REPO=$(cd "$(dirname "$0")/.." && pwd)
 
 ssh_opts=(-o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10)
+# "$@" is this function's own arguments, forwarded to form the remote command --
+# client-side expansion is the point, and there is no remote value to quote.
+# shellcheck disable=SC2029
 ssh_dev() { ssh "${ssh_opts[@]}" "$HOST" "$@"; }
 
 mkdir -p "$OUTDIR"

--- a/tools/kiosk-find.sh
+++ b/tools/kiosk-find.sh
@@ -66,17 +66,20 @@ win_ps() {
 # `timeout` is what bounds a filtered port, which otherwise hangs for the
 # kernel's full SYN retry.
 tcp_open() {
-    timeout 4 bash -c 'exec 3<>/dev/tcp/$1/$2' _ "$1" "$2" 2>/dev/null
+    # The \$ are escaped, not expanded: $1/$2 are the CHILD bash's positionals,
+    # passed as arguments, so no value is ever interpolated into the script text.
+    timeout 4 bash -c "exec 3<>/dev/tcp/\$1/\$2" _ "$1" "$2" 2>/dev/null
 }
 
 # The banner is whatever the server volunteers before we say anything. Reading
 # it is not a login attempt and leaves no session behind.
 tcp_banner() {
-    timeout 5 bash -c '
-        exec 3<>/dev/tcp/$1/$2 || exit 1
+    # Escaped \$ as in tcp_open: every $ below belongs to the child bash.
+    timeout 5 bash -c "
+        exec 3<>/dev/tcp/\$1/\$2 || exit 1
         IFS= read -r -t 3 line <&3
-        printf "%s" "$line"
-    ' _ "$1" "$2" 2>/dev/null | tr -d '\r'
+        printf '%s' \"\$line\"
+    " _ "$1" "$2" 2>/dev/null | tr -d '\r'
 }
 
 # Same probe from the Windows side, for a port WSL's NAT cannot reach.

--- a/tools/kiosk-screenshot.sh
+++ b/tools/kiosk-screenshot.sh
@@ -57,10 +57,17 @@ REMOTE=/data/kiosk-screenshot.$$.png
 
 # Clock and capture in ONE invocation: two invocations put an unknown gap
 # between the reference time and the pixels it is supposed to date.
+#
+# $REMOTE carries this run's local PID and must expand HERE, on the client, so
+# the staged path is the one the scp below fetches. Deliberate, not an oversight.
+# shellcheck disable=SC2029
 DEVICE_TIME=$(ssh "${ssh_opts[@]}" "$HOST" "date '+%H:%M:%S'; DISPLAY=:0 import -window root $REMOTE") || {
     echo "capture failed on the device" >&2; exit 1; }
 
 scp "${ssh_opts[@]}" "$HOST:$REMOTE" "$OUT" > /dev/null || { echo "could not fetch $REMOTE" >&2; exit 1; }
+# Same client-side $REMOTE as the capture above: this must remove the exact path
+# this run staged, not whatever a remote expansion would produce.
+# shellcheck disable=SC2029
 ssh "${ssh_opts[@]}" "$HOST" "rm -f $REMOTE" || true
 
 [ -s "$OUT" ] || { echo "$OUT is empty -- the capture did not survive the copy" >&2; exit 1; }

--- a/tools/rauc-rotate-verify.sh
+++ b/tools/rauc-rotate-verify.sh
@@ -48,7 +48,7 @@ if [ "${1:-}" = "--empirical" ]; then
     elif [ "$(printf '%s' "$OUT" | grep -ciE 'signature|verif|not trusted|unknown ca|certificate')" -gt 0 ]; then
         echo "  ok: old-signed bundle rejected for a signature/trust reason"
     else
-        echo "FAIL: old-signed bundle failed, but NOT for a signature reason -- inconclusive:"; echo "$OUT" | sed 's/^/    /'; rc=1
+        echo "FAIL: old-signed bundle failed, but NOT for a signature reason -- inconclusive:"; printf '%s\n' "$OUT" | sed 's/^/    /'; rc=1
     fi
 
     echo "== empirical positive: a NEW-signed bundle must be ACCEPTED"

--- a/tools/reproducibility-gate.sh
+++ b/tools/reproducibility-gate.sh
@@ -136,7 +136,7 @@ if [ "$mode" = "image" ]; then
             refuse "the image was not built from HEAD:"
             printf '        image: %s\n' "$commit" >&2
             printf '        HEAD : %s\n' "$HEAD" >&2
-            printf '        run `just build` -- the host sha is in do_image'\''s\n' >&2
+            printf "        run \`just build\` -- the host sha is in do_image's\n" >&2
             printf '        signature (kiosk-buildinfo-cachesafe), so a moved HEAD re-stamps.\n' >&2
             printf '        Or check out the commit the image came from.\n' >&2
         else


### PR DESCRIPTION
Adds static analysis and dependency hygiene for the repo **scaffolding** — the code a Yocto build never touches.

## What this adds
- **CodeQL** (`.github/workflows/codeql.yml`) — `python` + `actions`, `security-extended`, on push/PR/weekly. Covers the tooling (`doc-links.py`, `doc-image.py`, …) and the workflow files (script injection, unpinned actions, token scope).
- **Dependabot** (`.github/dependabot.yml`) — `github-actions` + `uv`, weekly, grouped minor/patch so a breaking major arrives on its own.
- **shellcheck + actionlint** (`.github/workflows/lint.yml`) — every tracked shell script (by extension **and** shebang, so `.githooks/pre-commit` is included) plus all workflow files. This covers the flash/ssh/dd shell surface that **CodeQL cannot see**.

New files only — `guards.yml` is untouched, so this merges independently of any in-flight `.github/` change.

## What this deliberately does NOT cover
- **The built image's packages** (WebKitGTK, openssl, systemd, …) — their CVE exposure needs BitBake `cve-check`, which runs inside a ~4.5 h build and cannot gate a PR. Tracked as a separate workstream.
- **Yocto layer pins** (poky/meta-oe/meta-autonomos SRCREVs in `includes/`) — invisible to Dependabot by construction; see the `dependabot.yml` comment.
- **Justfile `[script('bash')]` bodies** — embedded in `.just`, not lintable by shellcheck (noted in `lint.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)