### PR TITLE
#69 image CVE baseline: pin the SBOM, add an opt-in cve-check audit build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,8 +5,9 @@ name: codeql
 # unpinned actions, over-broad tokens). It does NOT see shell -- most of this
 # repo's logic and its whole flash/ssh/dd surface -- which lint.yml (shellcheck)
 # covers instead; nor the built image's packages, which BitBake's cve-check
-# would cover. A green run here is a statement about the scaffolding, not the
-# appliance.
+# covers from a local audit build that no workflow runs -- see
+# docs/cve-and-sbom.md. A green run here is a statement about the scaffolding,
+# not the appliance.
 on:
   push:
     branches: [main]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ One owner per fact. Read the owner; do not restate it here or anywhere else.
 | How YAML and recipes become an image, and which commit an image is from | [`docs/layers-and-kas.md`](docs/layers-and-kas.md) |
 | Which commit a *running* image was built from | `/etc/buildinfo` on the device |
 | Replacing the RAUC signing key, and the order it must happen in | [`docs/rauc-key-rotation.md`](docs/rauc-key-rotation.md) |
+| Scanning the image for CVEs, reading the SBOM, and what `CVE_STATUS` means | [`docs/cve-and-sbom.md`](docs/cve-and-sbom.md) |
 | What was tried, what it cost, what was rejected | [`docs/issue_investigation/`](docs/issue_investigation/TEMPLATE.md) |
 | The shape every investigation takes, and R1-R3 | [`docs/issue_investigation/TEMPLATE.md`](docs/issue_investigation/TEMPLATE.md) |
 | Site configuration — SSID, PSK hash, URL, hostname, machine-id | out-of-tree `~/.config/wisekiosk/secrets.yaml` |

--- a/Justfile
+++ b/Justfile
@@ -142,6 +142,33 @@ links:
 image:
     python3 tools/doc-image.py check
 
+# === Image audit ===
+
+# What the last audit build found: counts by every status the manifest carries,
+# and the unpatched findings listed. Reading only -- which finding matters is a
+# person's judgement, so this reports and never gates.
+[group('audit')]
+[doc("Report the CVE findings from the last audit build (skips if unbuilt)")]
+cve:
+    python3 tools/cve-report.py check
+
+# The SBOM every ordinary build already emits. No audit build needed.
+[group('audit')]
+[doc("Report the SBOM the last build emitted (skips if unbuilt)")]
+sbom:
+    python3 tools/sbom-report.py check
+
+# cve-check fetches the NVD database, so it rides an overlay fragment that only
+# this recipe joins on -- an ordinary `just build` keeps that fetch off its path.
+# write-build-rev.sh first, exactly as `build` does: kas alone builds the tree
+# against the PREVIOUS commit and the reproducibility gate refuses the image.
+[group('audit')]
+[script('bash')]
+[doc("Build with cve-check inherited, writing a CVE manifest beside the image")]
+cve-build:
+    tools/write-build-rev.sh
+    kas-container build {{config}}:includes/cve-audit.yaml
+
 # Write per-site config to a device's /data. The image carries none of it.
 [group('provision')]
 [doc("Provision a reachable device's /data from secrets.yaml")]

--- a/Justfile
+++ b/Justfile
@@ -144,23 +144,16 @@ image:
 
 # === Image audit ===
 
-# What the last audit build found: counts by every status the manifest carries,
-# and the unpatched findings listed. Reading only -- which finding matters is a
-# person's judgement, so this reports and never gates.
 [group('audit')]
 [doc("Report the CVE findings from the last audit build (skips if unbuilt)")]
 cve:
     python3 tools/cve-report.py check
 
-# The SBOM every ordinary build already emits. No audit build needed.
 [group('audit')]
 [doc("Report the SBOM the last build emitted (skips if unbuilt)")]
 sbom:
     python3 tools/sbom-report.py check
 
-# cve-check fetches the NVD database, so it rides an overlay fragment that only
-# this recipe joins on -- an ordinary `just build` keeps that fetch off its path.
-# write-build-rev.sh runs first, exactly as `build` does; see docs/cve-and-sbom.md.
 [group('audit')]
 [doc("Build with cve-check inherited, writing a CVE manifest beside the image")]
 cve-build:

--- a/Justfile
+++ b/Justfile
@@ -160,10 +160,8 @@ sbom:
 
 # cve-check fetches the NVD database, so it rides an overlay fragment that only
 # this recipe joins on -- an ordinary `just build` keeps that fetch off its path.
-# write-build-rev.sh first, exactly as `build` does: kas alone builds the tree
-# against the PREVIOUS commit and the reproducibility gate refuses the image.
+# write-build-rev.sh runs first, exactly as `build` does; see docs/cve-and-sbom.md.
 [group('audit')]
-[script('bash')]
 [doc("Build with cve-check inherited, writing a CVE manifest beside the image")]
 cve-build:
     tools/write-build-rev.sh

--- a/README.md
+++ b/README.md
@@ -249,7 +249,6 @@ Two more fixes belong upstream but did not need a patch, because a downstream la
   issue #7 debug-tweaks empty root password, which carries the detail.
 - **Screen blanking over a long idle is unverified.** `-s 0 -dpms -nocursor` moved from lightdm into
   the kiosk unit; that failure only appears after ~20 minutes.
-- **The image's packages are scanned for CVEs only when somebody asks.** `cve-check` rides an opt-in
-  audit build on a build host, never CI: a full build runs for hours, and a required check that can
-  never run reads green while measuring nothing. Nothing detects a stale scan, and deciding which
-  finding matters is manual. [CVE and SBOM](docs/cve-and-sbom.md)
+- **The image's packages are scanned for CVEs only when somebody asks.** The scan is a manual opt-in
+  audit build on a build host, and nothing detects that the last one was months ago. Deciding which
+  finding matters is manual too. [CVE and SBOM](docs/cve-and-sbom.md)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ meta-wisekiosk/                    <- the repository (project scaffolding)
 ├── includes/                      repo pins and machine config, pulled in by the above
 │   ├── base.yaml                  every repo + commit, incl. meta-autonomos and its patches
 │   ├── rauc.yaml
+│   ├── cve-audit.yaml             opt-in cve-check overlay, joined on by `just cve-build`
 │   └── platforms/
 │       ├── raspberrypi.yaml
 │       └── raspberrypi-zero-w.yaml
@@ -69,7 +70,8 @@ meta-wisekiosk/                    <- the repository (project scaffolding)
 ├── tools/                         provisioning, bundle delivery, device debugging, doc gate,
 │                                  CI guards, the identity scan, the build-commit writer and
 │                                  reproducibility gate
-├── docs/                          layers-and-kas.md, issue_investigation/
+├── docs/                          layers-and-kas.md, rauc-key-rotation.md, cve-and-sbom.md,
+│                                  issue_investigation/
 └── sources/                       gitignored; everything kas fetches lands here
 ```
 
@@ -247,3 +249,7 @@ Two more fixes belong upstream but did not need a patch, because a downstream la
   issue #7 debug-tweaks empty root password, which carries the detail.
 - **Screen blanking over a long idle is unverified.** `-s 0 -dpms -nocursor` moved from lightdm into
   the kiosk unit; that failure only appears after ~20 minutes.
+- **The image's packages are scanned for CVEs only when somebody asks.** `cve-check` rides an opt-in
+  audit build on a build host, never CI: a full build runs for hours, and a required check that can
+  never run reads green while measuring nothing. Nothing detects a stale scan, and deciding which
+  finding matters is manual. [CVE and SBOM](docs/cve-and-sbom.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 |---|---|
 | [`layers-and-kas.md`](layers-and-kas.md) | How does a tree of YAML and recipes become an image, for someone who has not used Yocto — and which commit is a given image from? |
 | [`rauc-key-rotation.md`](rauc-key-rotation.md) | How do you replace the RAUC signing key the devices trust, and why must it happen in a fixed order? |
+| [`cve-and-sbom.md`](cve-and-sbom.md) | What is the image made of, which of those packages carry published vulnerabilities, and how do you find out? |
 | [`issue_investigation/TEMPLATE.md`](issue_investigation/TEMPLATE.md) | What shape must an issue investigation take, and what must every test run in it name? |
 | [`issue_investigation/boot_cpu_saturation/`](issue_investigation/boot_cpu_saturation/README.md) | Across a boot, is the single core doing work, waiting on hardware, or queued behind something else? |
 | [`issue_investigation/wlan0_udev_queue/`](issue_investigation/wlan0_udev_queue/README.md) | What occupies the gap between the WiFi chip appearing on the bus and `wlan0` existing, and what is removing it worth? |

--- a/docs/cve-and-sbom.md
+++ b/docs/cve-and-sbom.md
@@ -132,9 +132,8 @@ does not run this scan and has no reason to hold a credential for it.
 
 ## Cost
 
-The figures below are what to expect on a first audit build, not measurements of any particular run;
-what a given run actually took is recorded in the validation record on the pull request that added
-this. An audit build is incremental over an ordinary `just build`. Neither `cve-check` nor `create-spdx`
+The figures below are what to expect on a first audit build, not measurements of any particular run.
+An audit build is incremental over an ordinary `just build`. Neither `cve-check` nor `create-spdx`
 changes what any recipe compiles, so WebKitGTK and the rest of the rootfs come back from sstate and
 the added work is the CVE tasks themselves rather than a rebuild.
 

--- a/docs/cve-and-sbom.md
+++ b/docs/cve-and-sbom.md
@@ -31,8 +31,8 @@ just cve-build
 
 That runs the same build as `just build` with the overlay fragment joined on, which is what
 `kas-container` does when a config path carries a colon. The build-revision stamp is written first,
-exactly as `just build` writes it — a build that skips it is built against the previous commit and
-the reproducibility gate refuses the resulting image.
+exactly as `just build` writes it; what depends on that is
+[`layers-and-kas.md`](layers-and-kas.md) §"What commit an image was built from".
 
 `cve-check` adds a task to each recipe and an image task that merges the results. On a warm tree that
 is incremental rather than a rebuild; what it costs is under Cost.
@@ -62,8 +62,9 @@ built. `TMPDIR` is set per machine, so the directory is `tmp-<machine>` rather t
 | SPDX roll-up beside the image | `images/<machine>/<image>.spdx.tar.zst` |
 | Packages installed in the image | `images/<machine>/<image>.manifest` |
 
-Each of these exists twice: once under a timestamped image name, and once as a stable symlink beside
-it. [`tools/cve-report.py`](../tools/cve-report.py) and [`tools/sbom-report.py`](../tools/sbom-report.py)
+Each of the `images/<machine>/` artifacts exists twice: once under a timestamped image name, and once
+as a stable symlink beside it. The per-recipe and per-package files are plain files with no second
+name. [`tools/cve-report.py`](../tools/cve-report.py) and [`tools/sbom-report.py`](../tools/sbom-report.py)
 resolve both and de-duplicate, so the newest build is what gets read whichever name you reach for.
 
 The roll-up archive is reported by path and not opened. Unpacking it needs `zstd`, which is not a
@@ -131,7 +132,9 @@ does not run this scan and has no reason to hold a credential for it.
 
 ## Cost
 
-An audit build is incremental over an ordinary `just build`. Neither `cve-check` nor `create-spdx`
+The figures below are what to expect on a first audit build, not measurements of any particular run;
+what a given run actually took is recorded in the validation record on the pull request that added
+this. An audit build is incremental over an ordinary `just build`. Neither `cve-check` nor `create-spdx`
 changes what any recipe compiles, so WebKitGTK and the rest of the rootfs come back from sstate and
 the added work is the CVE tasks themselves rather than a rebuild.
 

--- a/docs/cve-and-sbom.md
+++ b/docs/cve-and-sbom.md
@@ -1,0 +1,147 @@
+# CVE scanning and the SBOM
+
+This answers what the image is made of, and which of those pieces have published vulnerabilities.
+Static analysis covers the scaffolding in this repository — the Python tooling and the workflows —
+and says nothing about the several thousand packages BitBake assembles into the rootfs. That is
+where the exposure actually is: a browser engine, an SSL library, an init system and a kernel, all
+pinned by upstream recipes and all ageing at their own pace.
+
+Two artifacts answer it, and they are reached differently.
+
+## The two artifacts
+
+The **SBOM** is a set of SPDX documents, one per built package, written by the `create-spdx` class on
+every build. It costs nothing extra because it rides the build that was happening anyway.
+`kiosk-zero-w.yaml` names `create-spdx` in an `INHERIT` line so it keeps happening: the class also
+arrives transitively, because the `autonomos` distro config requires poky's, and a bump to either
+could take it away with nothing here noticing.
+
+The **CVE report** is a manifest listing every CVE that the NVD database associates with a package
+version in the image. `cve-check` produces it, and it is *not* part of an ordinary build. Enabling it
+means BitBake fetches and maintains a local copy of the NVD database, which puts a network dependency
+on the path of a build whose whole purpose is to produce a reproducible, flashable image. So it lives
+in the overlay fragment `includes/cve-audit.yaml`, joined onto the image config only when a scan is
+what you want.
+
+## Running the audit build
+
+```sh
+just cve-build
+```
+
+That runs the same build as `just build` with the overlay fragment joined on, which is what
+`kas-container` does when a config path carries a colon. The build-revision stamp is written first,
+exactly as `just build` writes it — a build that skips it is built against the previous commit and
+the reproducibility gate refuses the resulting image.
+
+An audit build on a warm tree is incremental. `cve-check` adds a task to each recipe and an image
+task that merges the results; it does not change any recipe's inputs, so it does not invalidate
+WebKitGTK or anything else that would cost a full rebuild. The dominant cost the first time is the
+NVD fetch described below, not compilation.
+
+Reading the results needs no build at all:
+
+```sh
+just cve
+just sbom
+```
+
+Both are read-only. Both skip loudly and exit clean when there is no build to read, and both refuse
+to report a pass when the artifact is present but reads as empty — a silent skip and a clean scan
+would otherwise be the same output.
+
+## Where the artifacts land
+
+Everything is under the gitignored `build/` tree, in the deploy directory for the machine that was
+built. `TMPDIR` is set per machine, so the directory is `tmp-<machine>` rather than a bare `tmp`.
+
+| Artifact | Path under `build/tmp-<machine>/deploy/` |
+|---|---|
+| CVE manifest, text | `images/<machine>/<image>.cve` |
+| CVE manifest, JSON | `images/<machine>/<image>.json` |
+| CVE findings per recipe | `cve/<recipe>` and `cve/<recipe>_cve.json` |
+| SPDX documents per package | `spdx/<version>/<arch>/packages/*.spdx.json` |
+| SPDX roll-up beside the image | `images/<machine>/<image>.spdx.tar.zst` |
+| Packages installed in the image | `images/<machine>/<image>.manifest` |
+
+Each of these exists twice: once under a timestamped image name, and once as a stable symlink beside
+it. [`tools/cve-report.py`](../tools/cve-report.py) and [`tools/sbom-report.py`](../tools/sbom-report.py)
+resolve both and de-duplicate, so the newest build is what gets read whichever name you reach for.
+
+The roll-up archive is reported by path and not opened. Unpacking it needs `zstd`, which is not a
+prerequisite for building this image, and the per-package documents beside it carry the same content.
+
+## Reading the CVE report
+
+`just cve` prints one line per unpatched finding — package, version, CVE, CVSS v3 base score, attack
+vector and the layer the recipe came from — then a count of every status in the manifest.
+
+The manifest itself is larger than that listing, deliberately. `CVE_CHECK_REPORT_PATCHED` defaults to
+enabled, so the file records CVEs that are already fixed as well as those that are not. Those records
+are worth keeping: a *Patched* entry is evidence that a fix was recognised, which is a different
+statement from a CVE never appearing at all. Filtering happens in the report script rather than in
+the build, so changing what gets shown costs a re-read instead of a rebuild.
+
+Nothing here decides which finding matters. A count of unpatched CVEs is not a risk assessment for a
+device that serves one URL over a LAN and accepts no inbound connection, and treating it as one
+produces either alarm or complacency. Triage is a person reading the list.
+
+## What CVE_STATUS means
+
+`cve-check` reports three statuses: **Patched**, **Unpatched** and **Ignored**. Patched and Unpatched
+it works out itself, by comparing the recipe's version against the versions NVD names as fixed and by
+noticing CVE identifiers in the recipe's patch filenames. Ignored is always a human statement.
+
+That statement is `CVE_STATUS`, set in the recipe or bbappend that owns the package — never in a
+config fragment, because the reasoning belongs beside the thing it is about. It takes a reason
+keyword and a justification:
+
+```
+CVE_STATUS[CVE-1234-0001] = "not-applicable-platform: only reachable on Windows"
+CVE_STATUS[CVE-1234-0002] = "cpe-stable-backport: fixed in the stable branch this recipe tracks"
+```
+
+The keyword is what maps to a status, through `CVE_CHECK_STATUSMAP` in poky's `cve-check-map.conf`.
+Keywords such as `cpe-stable-backport`, `backported-patch` and `fixed-version` map to **Patched** and
+say the scanner's version comparison was wrong. Keywords such as `not-applicable-platform`,
+`not-applicable-config`, `disputed`, `cpe-incorrect` and `upstream-wontfix` map to **Ignored** and say
+the CVE is real but does not reach this image. `vulnerable-investigating` maps to **Unpatched** and
+says the problem is confirmed with no fix available — it keeps the finding visible rather than
+silencing it.
+
+The justification text is the point. A keyword alone records that someone dismissed a CVE; the
+sentence after it records *why*, and is the only thing that lets the next reader tell a considered
+judgement from a wave-through.
+
+## The NVD database fetch
+
+`cve-check` needs NVD's data locally, and BitBake fetches it through NVD's public API. Unkeyed, that
+API is rate-limited hard enough that populating an empty database is the slowest part of a first
+audit build by a wide margin. Afterwards it fetches only the delta since the last run, which is
+quick, and the database persists in the build tree across builds.
+
+An API key removes most of that limit. NVD issues them free. It is an option, not a requirement, and
+if it is used it belongs in the build host's environment:
+
+```sh
+export NVDCVE_API_KEY=<key>
+```
+
+Set it where the build runs and nowhere else. It does not belong in this repository, which is public;
+it does not belong in a kas fragment, which is a build input; and it does not belong in CI, which
+does not run this scan and has no reason to hold a credential for it.
+
+## Why this is local only
+
+The scan runs on a build host, by hand, and reports to whoever ran it. Nothing gates on it.
+
+That is a consequence of what a Yocto build costs, not an oversight. CI here never builds the image —
+a full build runs for hours on hardware that GitHub's runners do not provide — so a per-pull-request
+CVE gate would be a check that could never run, and a required check that permanently skips is worse
+than no check at all: it reads green while measuring nothing.
+
+The consequence to hold onto is that a scan happens when somebody runs one. Nothing detects that the
+last audit build was months ago, and a stale manifest reads exactly like a fresh one, which is why
+both report scripts print the artifact's build time beside their counts. Closing that gap — a
+scheduled scan, a currency requirement, a threshold that can fail — is the rest of epic #61 image CVE
+scanning and SBOM, of which this baseline is the first leg.

--- a/docs/cve-and-sbom.md
+++ b/docs/cve-and-sbom.md
@@ -34,10 +34,8 @@ That runs the same build as `just build` with the overlay fragment joined on, wh
 exactly as `just build` writes it — a build that skips it is built against the previous commit and
 the reproducibility gate refuses the resulting image.
 
-An audit build on a warm tree is incremental. `cve-check` adds a task to each recipe and an image
-task that merges the results; it does not change any recipe's inputs, so it does not invalidate
-WebKitGTK or anything else that would cost a full rebuild. The dominant cost the first time is the
-NVD fetch described below, not compilation.
+`cve-check` adds a task to each recipe and an image task that merges the results. On a warm tree that
+is incremental rather than a rebuild; what it costs is under Cost.
 
 Reading the results needs no build at all:
 
@@ -130,6 +128,24 @@ export NVDCVE_API_KEY=<key>
 Set it where the build runs and nowhere else. It does not belong in this repository, which is public;
 it does not belong in a kas fragment, which is a build input; and it does not belong in CI, which
 does not run this scan and has no reason to hold a credential for it.
+
+## Cost
+
+An audit build is incremental over an ordinary `just build`. Neither `cve-check` nor `create-spdx`
+changes what any recipe compiles, so WebKitGTK and the rest of the rootfs come back from sstate and
+the added work is the CVE tasks themselves rather than a rebuild.
+
+The dominant cost is the keyless NVD download described above. `cve-update-nvd2-native` pulls the
+whole NVD 2.0 corpus, which with no `NVDCVE_API_KEY` set runs for an hour or two on a first audit
+build. Later ones reuse the cached database and finish in minutes.
+
+One signature does move. `cve-check` registers a rootfs postprocess,
+`cve_check_write_rootfs_manifest`, which changes the `do_rootfs` task signature and so re-runs
+`do_rootfs` and the image task behind it — a few minutes. That postprocess writes the manifest into
+the deploy directory and not into the rootfs, so the image's *contents* are the same as an ordinary
+build's and the package set that gets scanned is the one that would ship. The image an audit build
+produces is there to be scanned rather than flashed; the ordinary `just build` path carries no
+`cve-check` at all.
 
 ## Why this is local only
 

--- a/includes/cve-audit.yaml
+++ b/includes/cve-audit.yaml
@@ -1,0 +1,20 @@
+# Opt-in CVE audit overlay (#69 image CVE baseline).
+#
+# Colon-joined onto the image config for an audit build -- `just cve-build`, or
+# `kas-container build kiosk-zero-w.yaml:includes/cve-audit.yaml` -- and never
+# part of the ordinary build. cve-check fetches the NVD database, so inheriting
+# it in the base config would put a network fetch on the path of every build,
+# including the reproducible ones that produce a flashable image.
+#
+# The block name must stay unique across the whole include chain: kas merges
+# local_conf_header by name and a duplicate is discarded in silence.
+#
+# cve-check runs at its defaults here. Which findings matter is a reading
+# question, answered by tools/cve-report.py; CVE_STATUS triage belongs to the
+# recipe that carries the fix. See docs/cve-and-sbom.md.
+header:
+  version: 20
+
+local_conf_header:
+  cve-check: |
+    INHERIT += "cve-check"

--- a/includes/cve-audit.yaml
+++ b/includes/cve-audit.yaml
@@ -1,17 +1,9 @@
-# Opt-in CVE audit overlay (#69 image CVE baseline).
+# Opt-in CVE audit overlay (#69 image CVE baseline), colon-joined onto the image
+# config by `just cve-build` and never part of the ordinary build. See
+# docs/cve-and-sbom.md.
 #
-# Colon-joined onto the image config for an audit build -- `just cve-build`, or
-# `kas-container build kiosk-zero-w.yaml:includes/cve-audit.yaml` -- and never
-# part of the ordinary build. cve-check fetches the NVD database, so inheriting
-# it in the base config would put a network fetch on the path of every build,
-# including the reproducible ones that produce a flashable image.
-#
-# The block name must stay unique across the whole include chain: kas merges
-# local_conf_header by name and a duplicate is discarded in silence.
-#
-# cve-check runs at its defaults here. Which findings matter is a reading
-# question, answered by tools/cve-report.py; CVE_STATUS triage belongs to the
-# recipe that carries the fix. See docs/cve-and-sbom.md.
+# The block name must stay unique across the include chain: kas merges
+# local_conf_header by name and discards a duplicate in silence.
 header:
   version: 20
 

--- a/kiosk-zero-w.yaml
+++ b/kiosk-zero-w.yaml
@@ -173,11 +173,8 @@ local_conf_header:
     # See meta-wisekiosk/classes/kiosk-buildinfo-cachesafe.bbclass.
     IMAGE_CLASSES += "kiosk-buildinfo-cachesafe"
 
-    # The SBOM every build already emits (#69). create-spdx reaches this tree
-    # transitively -- autonomos.conf requires poky.conf, which inherits it --
-    # so a poky or meta-autonomos bump can drop it with nothing here noticing.
-    # Naming it makes the SBOM a property of this image rather than of an
-    # upstream default. See docs/cve-and-sbom.md.
+    # Named here, not left to poky.conf's transitive inherit, so an upstream
+    # bump cannot drop the SBOM (#69). See docs/cve-and-sbom.md.
     INHERIT += "create-spdx"
 
   # update-bundle.bb packages whichever image RAUC_SLOT_rootfs names, and its

--- a/kiosk-zero-w.yaml
+++ b/kiosk-zero-w.yaml
@@ -173,6 +173,13 @@ local_conf_header:
     # See meta-wisekiosk/classes/kiosk-buildinfo-cachesafe.bbclass.
     IMAGE_CLASSES += "kiosk-buildinfo-cachesafe"
 
+    # The SBOM every build already emits (#69). create-spdx reaches this tree
+    # transitively -- autonomos.conf requires poky.conf, which inherits it --
+    # so a poky or meta-autonomos bump can drop it with nothing here noticing.
+    # Naming it makes the SBOM a property of this image rather than of an
+    # upstream default. See docs/cve-and-sbom.md.
+    INHERIT += "create-spdx"
+
   # update-bundle.bb packages whichever image RAUC_SLOT_rootfs names, and its
   # default is autonomos-devel -- a different image, with no surf and no kiosk
   # unit. Installing that bundle would replace the slot and report success.

--- a/tools/cve-report.py
+++ b/tools/cve-report.py
@@ -3,24 +3,7 @@
 
     cve-report.py check     -- counts by status, and every unpatched finding
 
-cve-check is not part of the ordinary build: it fetches the NVD database, which
-has no business on the path of a build that produces a flashable image. It is
-inherited by includes/cve-audit.yaml and reached through `just cve-build`. This
-reads what that build deposited and does nothing else -- it changes no file,
-decides no triage, and gates nothing.
-
-The manifest carries Patched and Ignored records alongside the Unpatched ones,
-because CVE_CHECK_REPORT_PATCHED defaults to 1 and a patched record is the
-evidence that a fix was recognised rather than missed. Counting every status and
-listing only the unpatched is the filtering the audit build deliberately leaves
-undone: the manifest stays the full record, and the reading of it is here, where
-it can change without a rebuild.
-
-With no audit build in the tree this says so and exits clean. A Yocto build runs
-for hours and cannot gate a commit, but silence would be indistinguishable from
-a scan that found nothing, which is the failure the whole script guards against.
-A manifest that parses to zero records is the opposite case -- the artifact is
-there and the reading of it failed -- and that refuses to report a pass.
+The manifest comes from `just cve-build`. See docs/cve-and-sbom.md.
 """
 import re
 import subprocess
@@ -29,28 +12,23 @@ from collections import Counter
 from datetime import datetime
 from pathlib import Path
 
-# tmp-<machine>, not tmp/: TMPDIR is ${TOPDIR}/tmp-${MACHINE} in kiosk-zero-w.yaml,
-# so a host that has built for more than one machine has more than one tree.
-# cve-check writes a timestamped manifest and a stable symlink beside it, and
-# both match this -- resolving de-duplicates them.
+# tmp-<machine>, not tmp/: TMPDIR is ${TOPDIR}/tmp-${MACHINE}, so a host that has
+# built for more than one machine has more than one tree. Matches both the
+# timestamped manifest and its symlink; resolving de-duplicates them.
 MANIFEST_GLOB = "build/tmp-*/deploy/images/*/*.cve"
 
-# The per-recipe half of cve-check's output, one file per recipe. Read only when
-# the manifest is missing, to tell a tree that never ran an audit build from one
-# whose build stopped after do_cve_check. With a manifest present it adds
-# nothing: the manifest is the merged form of the same findings.
+# cve-check's per-recipe output. Distinguishes a tree that never ran an audit
+# build from one whose build stopped after do_cve_check.
 RECIPE_DIR_GLOB = "build/tmp-*/deploy/cve"
 
-# Every record in the text manifest opens with this key. The fields after it are
-# order-independent and some are conditional, so nothing may depend on position.
+# Every record opens with this key; the fields after it are order-independent.
 RECORD_START = "LAYER"
 
 # cve-check writes exactly three: Patched, Ignored, and this one.
 STATUS = "CVE STATUS"
 UNPATCHED = "Unpatched"
 
-# `KEY: value`, where the key is upper-case words and the value may hold colons
-# (MORE INFORMATION is a URL).
+# `KEY: value`; the value may hold colons (MORE INFORMATION is a URL).
 FIELD = re.compile(r"^([A-Z][A-Za-z0-9 ]*):[ ]?(.*)$")
 
 
@@ -63,11 +41,8 @@ def repo_top() -> Path:
 def records(text):
     """The manifest's `KEY: value` blocks, as dicts.
 
-    Split on the LAYER key rather than on blank lines: CVE SUMMARY and CVE
-    DESCRIPTION are free NVD prose and may carry one. A line that is not a
-    `KEY: value` pair is a continuation of the field above it and holds nothing
-    read here; a continuation that happens to look like a pair adds a key no
-    caller asks for, which is inert."""
+    Split on the LAYER key, not on blank lines: CVE SUMMARY and CVE DESCRIPTION
+    are free NVD prose and may carry one."""
     rec = None
     for line in text.splitlines():
         m = FIELD.match(line)
@@ -88,8 +63,8 @@ def records(text):
 def find_manifest(top: Path):
     """The most recently written CVE manifest under build/, or None.
 
-    By mtime: the deploy directory is not clamped to SOURCE_DATE_EPOCH the way
-    the rootfs is, so the file's own timestamp is the build that wrote it."""
+    By mtime: deploy/ is not clamped to SOURCE_DATE_EPOCH the way the rootfs
+    is, so the file's own timestamp is the build that wrote it."""
     unique = {p.resolve() for p in top.glob(MANIFEST_GLOB)}
     found = sorted((p for p in unique if p.is_file()),
                    key=lambda p: p.stat().st_mtime, reverse=True)
@@ -100,9 +75,7 @@ def check() -> int:
     top = repo_top()
     manifest = find_manifest(top)
     if manifest is None:
-        # Loud, on stdout, and exit 0 -- see the module docstring. cve-check is
-        # opt-in, so an ordinary build reaching here is the expected state, not
-        # a fault.
+        # cve-check is opt-in, so no manifest is the expected state, not a fault.
         per_recipe = [p for d in top.glob(RECIPE_DIR_GLOB) if d.is_dir()
                       for p in d.iterdir() if p.is_file()]
         if per_recipe:
@@ -133,17 +106,13 @@ def check() -> int:
 
     packages = {r.get("PACKAGE NAME") for r in unpatched}
     by_status = ", ".join(f"{n} {s}" for s, n in sorted(counts.items()))
-    # The build time is printed because a weeks-old manifest reads exactly like
-    # today's, and a stale one is the wrong answer stated confidently.
     built = datetime.fromtimestamp(manifest.stat().st_mtime).strftime("%Y-%m-%d %H:%M")
     print(f"\n{len(unpatched)} unpatched across {len(packages)} packages, "
           f"{len(parsed)} records total ({by_status})")
     print(f"manifest: {manifest.relative_to(top)} (built {built})")
 
-    # Exit 0 with findings. Which unpatched CVE matters to a device that serves
-    # one URL is a judgement made by a person, and this recipe sits outside
-    # `just verify` and outside CI precisely so it cannot become a gate. A
-    # nonzero exit is reserved for a report that cannot be trusted.
+    # Reports, never gates: exit 0 with findings. A nonzero exit is reserved for
+    # a report that cannot be trusted. See docs/cve-and-sbom.md.
     return 0
 
 

--- a/tools/cve-report.py
+++ b/tools/cve-report.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Read the CVE manifest an audit build leaves behind.
+
+    cve-report.py check     -- counts by status, and every unpatched finding
+
+cve-check is not part of the ordinary build: it fetches the NVD database, which
+has no business on the path of a build that produces a flashable image. It is
+inherited by includes/cve-audit.yaml and reached through `just cve-build`. This
+reads what that build deposited and does nothing else -- it changes no file,
+decides no triage, and gates nothing.
+
+The manifest carries Patched and Ignored records alongside the Unpatched ones,
+because CVE_CHECK_REPORT_PATCHED defaults to 1 and a patched record is the
+evidence that a fix was recognised rather than missed. Counting every status and
+listing only the unpatched is the filtering the audit build deliberately leaves
+undone: the manifest stays the full record, and the reading of it is here, where
+it can change without a rebuild.
+
+With no audit build in the tree this says so and exits clean. A Yocto build runs
+for hours and cannot gate a commit, but silence would be indistinguishable from
+a scan that found nothing, which is the failure the whole script guards against.
+A manifest that parses to zero records is the opposite case -- the artifact is
+there and the reading of it failed -- and that refuses to report a pass.
+"""
+import re
+import subprocess
+import sys
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+
+# tmp-<machine>, not tmp/: TMPDIR is ${TOPDIR}/tmp-${MACHINE} in kiosk-zero-w.yaml,
+# so a host that has built for more than one machine has more than one tree.
+# cve-check writes a timestamped manifest and a stable symlink beside it, and
+# both match this -- resolving de-duplicates them.
+MANIFEST_GLOB = "build/tmp-*/deploy/images/*/*.cve"
+
+# The per-recipe half of cve-check's output, one file per recipe. Reported
+# alongside the manifest because a doc that says where findings land has to name
+# both, and because its absence beside a present manifest is worth seeing.
+RECIPE_DIR_GLOB = "build/tmp-*/deploy/cve"
+
+# Every record in the text manifest opens with this key. The fields after it are
+# order-independent and some are conditional, so nothing may depend on position.
+RECORD_START = "LAYER"
+
+# cve-check writes exactly three: Patched, Ignored, and this one.
+STATUS = "CVE STATUS"
+UNPATCHED = "Unpatched"
+
+# `KEY: value`, where the key is upper-case words and the value may hold colons
+# (MORE INFORMATION is a URL).
+FIELD = re.compile(r"^([A-Z][A-Za-z0-9 ]*):[ ]?(.*)$")
+
+
+def repo_top() -> Path:
+    return Path(subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                               capture_output=True, text=True,
+                               check=True).stdout.strip())
+
+
+def records(text):
+    """The manifest's `KEY: value` blocks, as dicts.
+
+    Split on the LAYER key rather than on blank lines: CVE SUMMARY and CVE
+    DESCRIPTION are free NVD prose and may carry one. A line that is not a
+    `KEY: value` pair is a continuation of the field above it and holds nothing
+    read here; a continuation that happens to look like a pair adds a key no
+    caller asks for, which is inert."""
+    rec = None
+    for line in text.splitlines():
+        m = FIELD.match(line)
+        if not m:
+            continue
+        key, value = m.group(1), m.group(2)
+        if key == RECORD_START:
+            if rec is not None:
+                yield rec
+            rec = {}
+        if rec is None:
+            continue
+        rec[key] = value
+    if rec is not None:
+        yield rec
+
+
+def find_manifest(top: Path):
+    """The most recently written CVE manifest under build/, or None.
+
+    By mtime: the deploy directory is not clamped to SOURCE_DATE_EPOCH the way
+    the rootfs is, so the file's own timestamp is the build that wrote it."""
+    unique = {p.resolve() for p in top.glob(MANIFEST_GLOB)}
+    found = sorted((p for p in unique if p.is_file()),
+                   key=lambda p: p.stat().st_mtime, reverse=True)
+    return found[0] if found else None
+
+
+def check() -> int:
+    top = repo_top()
+    manifest = find_manifest(top)
+    if manifest is None:
+        # Loud, on stdout, and exit 0 -- see the module docstring. cve-check is
+        # opt-in, so an ordinary build reaching here is the expected state, not
+        # a fault.
+        print(f"SKIPPED: no CVE manifest under {MANIFEST_GLOB} and no per-recipe "
+              f"output under {RECIPE_DIR_GLOB} -- `just cve-build` writes both")
+        return 0
+
+    parsed = list(records(manifest.read_text(errors="replace")))
+    if not parsed:
+        print(f"{manifest} holds no CVE records -- refusing to report a pass",
+              file=sys.stderr)
+        return 2
+
+    counts = Counter(r.get(STATUS, "(no status)") for r in parsed)
+    unpatched = [r for r in parsed if r.get(STATUS) == UNPATCHED]
+
+    for r in sorted(unpatched, key=lambda r: (r.get("PACKAGE NAME", ""),
+                                              r.get("CVE", ""))):
+        print(f"{r.get('PACKAGE NAME', '?')} {r.get('PACKAGE VERSION', '?')}  "
+              f"{r.get('CVE', '?')}  CVSSv3 {r.get('CVSS v3 BASE SCORE', '?')}  "
+              f"{r.get('VECTOR', '?')}  [{r.get('LAYER', '?')}]")
+
+    packages = {r.get("PACKAGE NAME") for r in unpatched}
+    by_status = ", ".join(f"{n} {s}" for s, n in sorted(counts.items()))
+    # The build time is printed because a weeks-old manifest reads exactly like
+    # today's, and a stale one is the wrong answer stated confidently.
+    built = datetime.fromtimestamp(manifest.stat().st_mtime).strftime("%Y-%m-%d %H:%M")
+    print(f"\n{len(unpatched)} unpatched across {len(packages)} packages, "
+          f"{len(parsed)} records total ({by_status})")
+    print(f"manifest: {manifest.relative_to(top)} (built {built})")
+
+    # Exit 0 with findings. Which unpatched CVE matters to a device that serves
+    # one URL is a judgement made by a person, and this recipe sits outside
+    # `just verify` and outside CI precisely so it cannot become a gate. A
+    # nonzero exit is reserved for a report that cannot be trusted.
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) == 2 and sys.argv[1] == "check":
+        return check()
+    print(__doc__.strip().split("\n\n")[1], file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/cve-report.py
+++ b/tools/cve-report.py
@@ -35,9 +35,10 @@ from pathlib import Path
 # both match this -- resolving de-duplicates them.
 MANIFEST_GLOB = "build/tmp-*/deploy/images/*/*.cve"
 
-# The per-recipe half of cve-check's output, one file per recipe. Reported
-# alongside the manifest because a doc that says where findings land has to name
-# both, and because its absence beside a present manifest is worth seeing.
+# The per-recipe half of cve-check's output, one file per recipe. Read only when
+# the manifest is missing, to tell a tree that never ran an audit build from one
+# whose build stopped after do_cve_check. With a manifest present it adds
+# nothing: the manifest is the merged form of the same findings.
 RECIPE_DIR_GLOB = "build/tmp-*/deploy/cve"
 
 # Every record in the text manifest opens with this key. The fields after it are
@@ -102,8 +103,17 @@ def check() -> int:
         # Loud, on stdout, and exit 0 -- see the module docstring. cve-check is
         # opt-in, so an ordinary build reaching here is the expected state, not
         # a fault.
-        print(f"SKIPPED: no CVE manifest under {MANIFEST_GLOB} and no per-recipe "
-              f"output under {RECIPE_DIR_GLOB} -- `just cve-build` writes both")
+        per_recipe = [p for d in top.glob(RECIPE_DIR_GLOB) if d.is_dir()
+                      for p in d.iterdir() if p.is_file()]
+        if per_recipe:
+            print(f"SKIPPED: no CVE manifest under {MANIFEST_GLOB}, but "
+                  f"{len(per_recipe)} per-recipe report(s) present under "
+                  f"{RECIPE_DIR_GLOB} -- the build likely stopped after "
+                  "do_cve_check; re-run `just cve-build`")
+        else:
+            print(f"SKIPPED: no CVE manifest under {MANIFEST_GLOB} and no "
+                  f"per-recipe output under {RECIPE_DIR_GLOB} "
+                  "-- `just cve-build` writes both")
         return 0
 
     parsed = list(records(manifest.read_text(errors="replace")))

--- a/tools/sbom-report.py
+++ b/tools/sbom-report.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Report the SBOM the build emitted: where it is, and how much it describes.
+
+    sbom-report.py check    -- artifacts, SPDX version, and document counts
+
+create-spdx runs on every build -- kiosk-zero-w.yaml names it so that stays true
+across an upstream bump -- so unlike the CVE manifest this needs no audit build.
+What it did not do until now is surface: the documents landed under deploy/ and
+nothing said they were there or how many there were.
+
+Counts come from the SPDX documents themselves and from the image manifest,
+which are two independent statements about the same image. The manifest lists
+what was installed; the SPDX tree describes every package built, including the
+-dbg and -dev variants no image carries, so the two numbers are expected to
+differ and are printed side by side rather than reconciled.
+
+The rolled-up `.spdx.tar.zst` beside the image is reported by path only. Opening
+it needs zstd, which is not a build-host prerequisite here, and a report that
+refuses to run on a host missing an optional tool is a report nobody runs.
+
+With no build in the tree this says so and exits clean, for the reason
+doc-image.py's check does. An SPDX tree that holds no documents is the other
+case -- the directory is there and the reading of it failed -- and that refuses
+to report a pass.
+"""
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# The version directory create-spdx writes under, discovered rather than
+# assumed: the name IS the SPDX version, and reading it means a bump to 3.0
+# shows up in the report instead of emptying it.
+SPDX_ROOT_GLOB = "build/tmp-*/deploy/spdx/*"
+
+# One document per built package, per architecture directory.
+PACKAGE_GLOB = "*/packages/*.spdx.json"
+
+# The rolled-up archive beside the image, and the plain-text list of what the
+# rootfs actually installed. Both exist twice -- timestamped and symlinked --
+# so both are resolved and de-duplicated.
+ARCHIVE_GLOB = "build/tmp-*/deploy/images/*/*.spdx.tar.zst"
+IMAGE_MANIFEST_GLOB = "build/tmp-*/deploy/images/*/*.manifest"
+
+
+def repo_top() -> Path:
+    return Path(subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                               capture_output=True, text=True,
+                               check=True).stdout.strip())
+
+
+def newest(top: Path, pattern: str):
+    """The most recently written match for a glob, or None.
+
+    By mtime, resolved and de-duplicated. The deploy directory is not clamped to
+    SOURCE_DATE_EPOCH the way the rootfs is, so a file's own timestamp is the
+    build that wrote it."""
+    unique = {p.resolve() for p in top.glob(pattern)}
+    found = sorted(unique, key=lambda p: p.stat().st_mtime, reverse=True)
+    return found[0] if found else None
+
+
+def check() -> int:
+    top = repo_top()
+    root = newest(top, SPDX_ROOT_GLOB)
+    if root is None or not root.is_dir():
+        # Loud, on stdout, and exit 0: a Yocto build is hours and cannot gate a
+        # commit, but a silent skip would read exactly like a clean report.
+        print(f"SKIPPED: no SPDX output under {SPDX_ROOT_GLOB} "
+              "-- `just build` writes it")
+        return 0
+
+    documents = sorted(root.glob(PACKAGE_GLOB))
+    if not documents:
+        print(f"{root} holds no package documents -- refusing to report a pass",
+              file=sys.stderr)
+        return 2
+
+    per_arch = {}
+    for doc in documents:
+        per_arch[doc.parent.parent.name] = per_arch.get(doc.parent.parent.name, 0) + 1
+    for arch, n in sorted(per_arch.items()):
+        print(f"{n:6d}  {arch}")
+
+    built = datetime.fromtimestamp(root.stat().st_mtime).strftime("%Y-%m-%d %H:%M")
+    print(f"\n{len(documents)} SPDX package documents, "
+          f"SPDX {root.name}, in {root.relative_to(top)} (built {built})")
+
+    archive = newest(top, ARCHIVE_GLOB)
+    if archive is None:
+        # Not a failure: the per-package documents above are the SBOM. The
+        # archive is the shippable roll-up of them, and its absence is worth
+        # naming rather than passing over.
+        print(f"no rolled-up archive under {ARCHIVE_GLOB}")
+    else:
+        mb = archive.stat().st_size / (1024 * 1024)
+        print(f"archive:  {archive.relative_to(top)} ({mb:.1f} MiB, not opened here)")
+
+    manifest = newest(top, IMAGE_MANIFEST_GLOB)
+    if manifest is None:
+        print(f"no image manifest under {IMAGE_MANIFEST_GLOB}")
+    else:
+        installed = sum(1 for line in manifest.read_text(errors="replace").splitlines()
+                        if line.strip())
+        print(f"manifest: {manifest.relative_to(top)} "
+              f"({installed} packages installed in the image)")
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) == 2 and sys.argv[1] == "check":
+        return check()
+    print(__doc__.strip().split("\n\n")[1], file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/sbom-report.py
+++ b/tools/sbom-report.py
@@ -5,8 +5,8 @@
 
 create-spdx runs on every build -- kiosk-zero-w.yaml names it so that stays true
 across an upstream bump -- so unlike the CVE manifest this needs no audit build.
-What it did not do until now is surface: the documents landed under deploy/ and
-nothing said they were there or how many there were.
+What it does not do is surface what it wrote: the documents land under deploy/
+and nothing there says they are present or how many of them there are.
 
 Counts come from the SPDX documents themselves and from the image manifest,
 which are two independent statements about the same image. The manifest lists
@@ -54,9 +54,11 @@ def newest(top: Path, pattern: str):
 
     By mtime, resolved and de-duplicated. The deploy directory is not clamped to
     SOURCE_DATE_EPOCH the way the rootfs is, so a file's own timestamp is the
-    build that wrote it."""
+    build that wrote it. A resolved path that does not exist is a symlink whose
+    target was pruned, and is skipped rather than stat'ed."""
     unique = {p.resolve() for p in top.glob(pattern)}
-    found = sorted(unique, key=lambda p: p.stat().st_mtime, reverse=True)
+    found = sorted((p for p in unique if p.exists()),
+                   key=lambda p: p.stat().st_mtime, reverse=True)
     return found[0] if found else None
 
 
@@ -82,11 +84,17 @@ def check() -> int:
     for arch, n in sorted(per_arch.items()):
         print(f"{n:6d}  {arch}")
 
-    built = datetime.fromtimestamp(root.stat().st_mtime).strftime("%Y-%m-%d %H:%M")
+    # From a file the build wrote, not from the version directory: a directory's
+    # mtime moves only when an entry is added or removed, so an incremental
+    # rebuild into the same arch directories would leave it reading weeks old.
+    # The roll-up archive is the per-build artifact; the newest package document
+    # stands in for a tree whose image task has not run.
+    archive = newest(top, ARCHIVE_GLOB)
+    stamp = archive or max(documents, key=lambda p: p.stat().st_mtime)
+    built = datetime.fromtimestamp(stamp.stat().st_mtime).strftime("%Y-%m-%d %H:%M")
     print(f"\n{len(documents)} SPDX package documents, "
           f"SPDX {root.name}, in {root.relative_to(top)} (built {built})")
 
-    archive = newest(top, ARCHIVE_GLOB)
     if archive is None:
         # Not a failure: the per-package documents above are the SBOM. The
         # archive is the shippable roll-up of them, and its absence is worth

--- a/tools/sbom-report.py
+++ b/tools/sbom-report.py
@@ -3,42 +3,24 @@
 
     sbom-report.py check    -- artifacts, SPDX version, and document counts
 
-create-spdx runs on every build -- kiosk-zero-w.yaml names it so that stays true
-across an upstream bump -- so unlike the CVE manifest this needs no audit build.
-What it does not do is surface what it wrote: the documents land under deploy/
-and nothing there says they are present or how many of them there are.
-
-Counts come from the SPDX documents themselves and from the image manifest,
-which are two independent statements about the same image. The manifest lists
-what was installed; the SPDX tree describes every package built, including the
--dbg and -dev variants no image carries, so the two numbers are expected to
-differ and are printed side by side rather than reconciled.
-
-The rolled-up `.spdx.tar.zst` beside the image is reported by path only. Opening
-it needs zstd, which is not a build-host prerequisite here, and a report that
-refuses to run on a host missing an optional tool is a report nobody runs.
-
-With no build in the tree this says so and exits clean, for the reason
-doc-image.py's check does. An SPDX tree that holds no documents is the other
-case -- the directory is there and the reading of it failed -- and that refuses
-to report a pass.
+create-spdx runs on every build, so this needs no audit build. The SPDX and
+manifest counts describe different sets -- every package built, against what the
+image installed -- and are printed side by side, not reconciled. See
+docs/cve-and-sbom.md.
 """
 import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
 
-# The version directory create-spdx writes under, discovered rather than
-# assumed: the name IS the SPDX version, and reading it means a bump to 3.0
-# shows up in the report instead of emptying it.
+# Globbed, not assumed: the directory name IS the SPDX version.
 SPDX_ROOT_GLOB = "build/tmp-*/deploy/spdx/*"
 
 # One document per built package, per architecture directory.
 PACKAGE_GLOB = "*/packages/*.spdx.json"
 
-# The rolled-up archive beside the image, and the plain-text list of what the
-# rootfs actually installed. Both exist twice -- timestamped and symlinked --
-# so both are resolved and de-duplicated.
+# Both exist twice -- timestamped and symlinked -- so both are resolved and
+# de-duplicated.
 ARCHIVE_GLOB = "build/tmp-*/deploy/images/*/*.spdx.tar.zst"
 IMAGE_MANIFEST_GLOB = "build/tmp-*/deploy/images/*/*.manifest"
 
@@ -52,10 +34,10 @@ def repo_top() -> Path:
 def newest(top: Path, pattern: str):
     """The most recently written match for a glob, or None.
 
-    By mtime, resolved and de-duplicated. The deploy directory is not clamped to
+    By mtime, resolved and de-duplicated. deploy/ is not clamped to
     SOURCE_DATE_EPOCH the way the rootfs is, so a file's own timestamp is the
-    build that wrote it. A resolved path that does not exist is a symlink whose
-    target was pruned, and is skipped rather than stat'ed."""
+    build that wrote it. A resolved path that does not exist is a pruned
+    symlink target, and is skipped rather than stat'ed."""
     unique = {p.resolve() for p in top.glob(pattern)}
     found = sorted((p for p in unique if p.exists()),
                    key=lambda p: p.stat().st_mtime, reverse=True)
@@ -66,8 +48,6 @@ def check() -> int:
     top = repo_top()
     root = newest(top, SPDX_ROOT_GLOB)
     if root is None or not root.is_dir():
-        # Loud, on stdout, and exit 0: a Yocto build is hours and cannot gate a
-        # commit, but a silent skip would read exactly like a clean report.
         print(f"SKIPPED: no SPDX output under {SPDX_ROOT_GLOB} "
               "-- `just build` writes it")
         return 0
@@ -84,11 +64,9 @@ def check() -> int:
     for arch, n in sorted(per_arch.items()):
         print(f"{n:6d}  {arch}")
 
-    # From a file the build wrote, not from the version directory: a directory's
-    # mtime moves only when an entry is added or removed, so an incremental
-    # rebuild into the same arch directories would leave it reading weeks old.
-    # The roll-up archive is the per-build artifact; the newest package document
-    # stands in for a tree whose image task has not run.
+    # Timestamp from a file, not the version directory: a directory's mtime moves
+    # only when an entry is added or removed, so an incremental rebuild into the
+    # same arch directories would leave it reading weeks old.
     archive = newest(top, ARCHIVE_GLOB)
     stamp = archive or max(documents, key=lambda p: p.stat().st_mtime)
     built = datetime.fromtimestamp(stamp.stat().st_mtime).strftime("%Y-%m-%d %H:%M")
@@ -96,9 +74,7 @@ def check() -> int:
           f"SPDX {root.name}, in {root.relative_to(top)} (built {built})")
 
     if archive is None:
-        # Not a failure: the per-package documents above are the SBOM. The
-        # archive is the shippable roll-up of them, and its absence is worth
-        # naming rather than passing over.
+        # Not a failure: the per-package documents above are the SBOM.
         print(f"no rolled-up archive under {ARCHIVE_GLOB}")
     else:
         mb = archive.stat().st_size / (1024 * 1024)


### PR DESCRIPTION
Leg A of epic #61 image and supply-chain scanning. Makes the built image scannable
locally: the SBOM becomes a property of this image rather than of an upstream
default, and cve-check becomes an opt-in audit build that keeps the NVD network
fetch off the path of every ordinary build.

## What each work item delivers

**WI-1 build config.** `kiosk-zero-w.yaml` names `INHERIT += "create-spdx"` in the
existing `kiosk:` block. It already reaches this tree transitively — `autonomos.conf`
`require`s `poky.conf`, which inherits it — so the SBOM builds today; pinning it is
what survives a poky or meta-autonomos bump. New `includes/cve-audit.yaml` is a kas
overlay fragment carrying `INHERIT += "cve-check"` under a `cve-check`
`local_conf_header` block, unique across the include chain. cve-check rides at its
defaults; filtering happens when the manifest is read.

**WI-2 reporting.** `tools/cve-report.py` and `tools/sbom-report.py`, cut from
`tools/doc-image.py`'s idioms — newest-match glob, loud SKIPPED and exit 0 with no
build, and a refusal to report a pass on an empty artifact. A `[group('audit')]` in
the `Justfile` wires `just cve`, `just sbom` and `just cve-build`; `cve-build` runs
`tools/write-build-rev.sh` before kas, as `just build` does.

**WI-3 docs.** New `docs/cve-and-sbom.md` owns the procedure: running the audit
build, reading the manifest, what `CVE_STATUS` triage means, where the artifacts
land, and the NVD API key as a build-box option. Hub row in `docs/README.md`, one
pointer row in `CLAUDE.md`, the stale cve-check clause in `codeql.yml` corrected,
and a residual bullet under `README.md` §"Known gaps".

## Validation, and what is out of scope

**WI-4 audit-build validation ran and passed** — `just cve-build` was run end to end on
the build box and exited 0; the `.cve` manifest appeared and both `just cve` and
`just sbom` produced real output. The figures, the incremental-vs-rebuild finding and
the `do_rootfs` nuance are in the WI-4 validation comment on this PR. Reporting is
read-only, writes nothing outside gitignored `build/`, is not wired into `just verify`,
and adds no CI.

Out of scope here are the remaining legs of the epic, each its own ticket: #70 continuous CVE scan,
#71 publish and delta-triage per audit build, and #72 recipe currency for image layers.

Closes #69

