### PR TITLE
#70 image CVE second-source scan: cross-check the SBOM with Grype

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -155,7 +155,7 @@ sbom:
     python3 tools/sbom-report.py check
 
 [group('audit')]
-[doc("Cross-check the SBOM against Grype for what cve-check missed (skips if unbuilt)")]
+[doc("Second-source findings the CVE manifest does not carry (skips if unbuilt)")]
 cve-scan:
     python3 tools/cve-scan.py check
 

--- a/Justfile
+++ b/Justfile
@@ -155,6 +155,11 @@ sbom:
     python3 tools/sbom-report.py check
 
 [group('audit')]
+[doc("Cross-check the SBOM against Grype for what cve-check missed (skips if unbuilt)")]
+cve-scan:
+    python3 tools/cve-scan.py check
+
+[group('audit')]
 [doc("Build with cve-check inherited, writing a CVE manifest beside the image")]
 cve-build:
     tools/write-build-rev.sh

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ behind those changes are indexed in **[docs/README.md](docs/README.md)**.
 
 ## Quick start
 
-`kas-container` runs the build inside a container, so a working **Docker or Podman** is a
+`kas-container` runs the build inside a container, so a working **Docker** is a
 prerequisite. The flash and OTA paths additionally need `git`, `debugfs` (`e2fsprogs`) and `openssl`,
 and the repository guards (`just guards` and the pre-commit hook) need **PyYAML** for `python3` to
 validate the kas YAML — all of them refuse rather than skip when one is missing. On an

--- a/docs/cve-and-sbom.md
+++ b/docs/cve-and-sbom.md
@@ -145,12 +145,11 @@ triage on the same terms as the rest: nothing here decides which findings matter
 
 ### What the scan needs
 
-Docker or Podman, whichever is installed — the same choice the build already makes, per
-[`../README.md`](../README.md) §"Quick start" — and two container images, both pinned in the script.
-The scanner is distroless and carries no `tar` and no `zstd`, so it cannot open the roll-up itself.
-The kas image can, and it is the image this repository builds with, so nothing asks the host for a
-tool the build did not already need and `zstd` never has to be installed. A kas bump in the README is
-a bump this pin has to be given too; nothing compares them.
+Docker, and two container images pinned in the script. The scanner is distroless and carries no `tar`
+and no `zstd`, so it cannot open the roll-up itself. The kas image can, and it is the image this
+repository builds with — [`../README.md`](../README.md) §"Quick start" holds that pin — so nothing
+asks the host for a tool the build did not already need, and `zstd` never has to be installed. A kas
+bump there is a bump this pin has to be given too; nothing compares them.
 
 | Image | What it does |
 |---|---|

--- a/docs/cve-and-sbom.md
+++ b/docs/cve-and-sbom.md
@@ -145,26 +145,34 @@ triage on the same terms as the rest: nothing here decides which findings matter
 
 ### What the scan needs
 
-Two container images, both pinned in the script. The scanner is distroless and carries no `tar` and
-no `zstd`, so it cannot open the roll-up itself; the kas image can, and it is already what builds
-this tree — see [`../README.md`](../README.md) §"Quick start". Nothing asks the host for a tool the
-build did not already need, and `zstd` never has to be installed.
+Docker or Podman, whichever is installed — the same choice the build already makes, per
+[`../README.md`](../README.md) §"Quick start" — and two container images, both pinned in the script.
+The scanner is distroless and carries no `tar` and no `zstd`, so it cannot open the roll-up itself.
+The kas image can, and it is the image this repository builds with, so nothing asks the host for a
+tool the build did not already need and `zstd` never has to be installed. A kas bump in the README is
+a bump this pin has to be given too; nothing compares them.
 
 | Image | What it does |
 |---|---|
 | `anchore/grype:v0.118.0` | scans the merged SBOM |
 | `ghcr.io/siemens/kas/kas:5.4` | unpacks the `.spdx.tar.zst` roll-up |
 
-Grype's vulnerability database is roughly 1.9 GB unpacked and is cached in `~/.cache/grype`, outside
-the repository and outside `build/`. It is too large for a tmpfs. The first run downloads it; later
-runs reuse it and finish in about twenty seconds.
+Grype's vulnerability database is cached in `~/.cache/grype`, outside the repository and outside
+`build/`. It is far too large for a tmpfs and only grows. The first run downloads it and later runs
+reuse it, which is most of why a repeat scan is quick — the scan itself is dominated by loading that
+database rather than by the size of the SBOM.
 
-That database expires hard: Grype refuses to run against one built more than five days ago. A host
-that scans offline therefore starts failing on the sixth day, reporting the age rather than returning
-a stale result quietly, and refreshing it takes a run with network access.
+The database also expires hard: Grype refuses to run against one built more than five days ago. A
+host that scans offline therefore starts failing once it passes that age, reporting the age rather
+than quietly returning a stale result, and refreshing it takes a run with network access.
 
 Beyond that cache the scan writes nothing. It unpacks the roll-up into a temporary directory inside
 the build tree and removes it on the way out.
+
+Both artifacts have to come from one build. `create-spdx` runs on every build and `cve-check` only on
+an audit build, so an ordinary `just build` after an audit build leaves a fresh SBOM beside a stale
+manifest — a pair that would report everything fixed since the audit as though `cve-check` had never
+seen it. The two filenames carry the same build stamp, and the scan refuses to run when they differ.
 
 ### Why the merge step exists
 
@@ -182,10 +190,15 @@ legal SPDX 2.2, so this is a limitation of the reader rather than malformed outp
 unrewritten, the scan runs clean, exits 0 and reports almost nothing: the shape of a check that looks
 green because it measured nothing.
 
-So the scan counts the packages in the merged document that carry a CPE Grype will actually read, and
-refuses to report a pass when that count is zero. An empty result *after* a real scan is reported as
-an empty result and exits clean; the refusal is reserved for a scan that never had anything to match
-against.
+So the scan checks both ends of the run. It counts the packages in the merged document carrying a CPE
+that Grype will actually read and refuses when that count is zero; and it refuses again when a scan
+over those packages comes back with no matches at all, because a reader that stopped understanding
+SPDX 2.2 would return a well-formed empty result that looks exactly like an image with nothing wrong
+with it.
+
+What exits clean is an empty *delta* — matches came back, and the manifest already accounted for
+every one of them. That is a different state from having measured nothing, and the exit codes keep
+the two apart.
 
 ## The NVD database fetch
 

--- a/docs/cve-and-sbom.md
+++ b/docs/cve-and-sbom.md
@@ -46,7 +46,8 @@ just sbom
 
 Both are read-only. Both skip loudly and exit clean when there is no build to read, and both refuse
 to report a pass when the artifact is present but reads as empty — a silent skip and a clean scan
-would otherwise be the same output.
+would otherwise be the same output. `just cve-scan` reads the same two artifacts through a second
+scanner and holds to the same three outcomes; it is under The second-source cross-check.
 
 ## Where the artifacts land
 
@@ -67,8 +68,10 @@ as a stable symlink beside it. The per-recipe and per-package files are plain fi
 name. [`tools/cve-report.py`](../tools/cve-report.py) and [`tools/sbom-report.py`](../tools/sbom-report.py)
 resolve both and de-duplicate, so the newest build is what gets read whichever name you reach for.
 
-The roll-up archive is reported by path and not opened. Unpacking it needs `zstd`, which is not a
-prerequisite for building this image, and the per-package documents beside it carry the same content.
+`just sbom` reports the roll-up archive by path and does not open it: unpacking needs `zstd`, which
+is not a prerequisite for building this image, and the per-package documents beside it carry the same
+content. The cross-check below does need the archive, and unpacks it in a container rather than
+adding that prerequisite.
 
 ## Reading the CVE report
 
@@ -111,6 +114,78 @@ silencing it.
 The justification text is the point. A keyword alone records that someone dismissed a CVE; the
 sentence after it records *why*, and is the only thing that lets the next reader tell a considered
 judgement from a wave-through.
+
+## The second-source cross-check
+
+`cve-check` is the authority on this image, and it is the only scanner here that can read the
+judgements described above. No other tool knows that a fix was backported or that a CVE was ruled
+not-applicable. That leaves a second scanner useful for one thing: finding what the first one had no
+entry for at all.
+
+```sh
+just cve-scan
+```
+
+[`tools/cve-scan.py`](../tools/cve-scan.py) takes the SPDX roll-up and the CVE manifest from the same
+deploy directory, scans the SBOM with Grype, and prints only what the manifest does not already
+carry. Grype's database draws on GHSA and other non-NVD sources and is rebuilt daily, so what
+survives the filter is largely advisories with no NVD entry, or ones published since the audit build
+last read NVD.
+
+The filter keys on the pair — package *and* CVE — rather than on the identifier alone. Two scanners
+can attribute one advisory to different packages, and a pair the manifest does not hold is worth
+showing even when the identifier appears elsewhere in it, because the disagreement is itself the
+finding.
+
+What comes back is a supplement, never a verdict. Grype cannot see `CVE_STATUS`, so on this image it
+re-reports several hundred CVEs already recorded as *Patched* or *Ignored*. The filter removes those,
+and it removes them because `cve-check` judged them rather than because Grype agreed. A finding that
+survives has been seen by one scanner and not considered by the other, which makes it a candidate for
+triage on the same terms as the rest: nothing here decides which findings matter.
+
+### What the scan needs
+
+Two container images, both pinned in the script. The scanner is distroless and carries no `tar` and
+no `zstd`, so it cannot open the roll-up itself; the kas image can, and it is already what builds
+this tree — see [`../README.md`](../README.md) §"Quick start". Nothing asks the host for a tool the
+build did not already need, and `zstd` never has to be installed.
+
+| Image | What it does |
+|---|---|
+| `anchore/grype:v0.118.0` | scans the merged SBOM |
+| `ghcr.io/siemens/kas/kas:5.4` | unpacks the `.spdx.tar.zst` roll-up |
+
+Grype's vulnerability database is roughly 1.9 GB unpacked and is cached in `~/.cache/grype`, outside
+the repository and outside `build/`. It is too large for a tmpfs. The first run downloads it; later
+runs reuse it and finish in about twenty seconds.
+
+That database expires hard: Grype refuses to run against one built more than five days ago. A host
+that scans offline therefore starts failing on the sixth day, reporting the age rather than returning
+a stale result quietly, and refreshing it takes a run with network access.
+
+Beyond that cache the scan writes nothing. It unpacks the roll-up into a temporary directory inside
+the build tree and removes it on the way out.
+
+### Why the merge step exists
+
+Grype reads one SBOM file and does not follow SPDX `externalDocumentRefs`. The roll-up is several
+thousand documents pointing at each other, so handing it over whole scans a single nameless image
+package and finds nothing. The script instead walks the image document to the binary packages it
+contains, each of those to the recipe it was generated from, and merges that closure into one
+document. Selecting on a `-native` or `-cross` name suffix instead over-reports, because a native
+build of a shipped recipe is a separate document carrying the same CPE.
+
+One string in that merge is load-bearing. `create-spdx` writes CPEs with the long-URI reference type
+`http://spdx.org/rdf/references/cpe23Type`, while syft — which Grype parses SPDX with — matches only
+the short `cpe23Type` and discards the reference silently at default verbosity. Both spellings are
+legal SPDX 2.2, so this is a limitation of the reader rather than malformed output from Yocto. Left
+unrewritten, the scan runs clean, exits 0 and reports almost nothing: the shape of a check that looks
+green because it measured nothing.
+
+So the scan counts the packages in the merged document that carry a CPE Grype will actually read, and
+refuses to report a pass when that count is zero. An empty result *after* a real scan is reported as
+an empty result and exits clean; the refusal is reserved for a scan that never had anything to match
+against.
 
 ## The NVD database fetch
 

--- a/tools/cve-scan.py
+++ b/tools/cve-scan.py
@@ -16,22 +16,32 @@ import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
-# tmp-<machine>, not tmp/: TMPDIR is ${TOPDIR}/tmp-${MACHINE}. The archive exists
-# twice -- timestamped and symlinked -- so both are resolved and de-duplicated.
+# tmp-<machine>, not tmp/: TMPDIR is ${TOPDIR}/tmp-${MACHINE}. Each artifact
+# exists twice -- timestamped and symlinked -- so both are resolved and
+# de-duplicated.
 ARCHIVE_GLOB = "build/tmp-*/deploy/images/*/*.spdx.tar.zst"
 
-# Read from the SBOM's own deploy directory: the two artifacts must describe one
-# build, which a second repository-wide glob would not guarantee.
+# Searched in the SBOM's own deploy directory. That narrows the field but does
+# not pair the two: create-spdx runs on every build and cve-check only on an
+# audit build, so the newest of each can come from different builds. What makes
+# them one build is the stamp both filenames carry, compared below.
 MANIFEST_GLOB = "*.cve"
+ARCHIVE_SUFFIX = ".spdx.tar.zst"
+MANIFEST_SUFFIX = ".cve"
 
 # Both pinned. The scanner image is distroless -- no shell, no tar, no zstd -- so
-# the unpack runs in the image that already builds this tree; see README
-# "Quick start" for the kas pin it belongs to.
+# the unpack borrows the kas image this repository builds with; see
+# ../README.md "Quick start", and mirror a bump there into this pin.
 GRYPE_IMAGE = "anchore/grype:v0.118.0"
 UNPACK_IMAGE = "ghcr.io/siemens/kas/kas:5.4"
 
-# Grype's v6 database unpacks to ~1.9 GB, which a tmpfs will not hold.
-DB_CACHE = Path.home() / ".cache" / "grype"
+# kas-container supports either, so the scan must not require one of them.
+RUNTIMES = ("docker", "podman")
+
+# Kept out of build/ and out of the repository: the database only grows, and a
+# tmpfs will not hold it. Spelled home-relative so no username is printed.
+DB_CACHE_SHOWN = "~/.cache/grype"
+DB_CACHE = Path(DB_CACHE_SHOWN).expanduser()
 
 # create-spdx writes the long URI form of this and syft's decoder matches only
 # the short one, dropping the CPE without saying so. See docs/cve-and-sbom.md.
@@ -104,19 +114,24 @@ def known_pairs(text):
     return pairs
 
 
-def docker(args):
+def runtime():
+    """Whichever container runtime is installed, preferring the first listed."""
+    return next((r for r in RUNTIMES if shutil.which(r)), None)
+
+
+def container(engine: str, args):
     """A pinned container, run as the invoking user.
 
     Grype's cache is unusable to a non-root run once a root run has written it,
     so every invocation here passes --user and none of them may drop it."""
     return subprocess.run(
-        ["docker", "run", "--rm", "--user", f"{os.getuid()}:{os.getgid()}"] + args,
+        [engine, "run", "--rm", "--user", f"{os.getuid()}:{os.getgid()}"] + args,
         capture_output=True, text=True)
 
 
-def unpack(archive: Path, dest: Path):
+def unpack(engine: str, archive: Path, dest: Path):
     """Extract the SPDX bundle without requiring zstd on the host."""
-    return docker([
+    return container(engine, [
         "-v", f"{archive.parent}:/in:ro",
         "-v", f"{dest}:/out",
         "--entrypoint", "tar", UNPACK_IMAGE,
@@ -167,7 +182,11 @@ def image_closure(bundle: Path, image_doc: Path):
                 continue
             for r in refs:
                 r["referenceType"] = CPE_REF
-            spdxid = "SPDXRef-" + re.sub(r"[^A-Za-z0-9.-]", "-", name)
+            # Per package, not per document: a duplicate SPDXID is invalid SPDX,
+            # and syft keeps one of the pair without saying which, shrinking the
+            # closure while every count here still reads correct.
+            spdxid = "SPDXRef-" + re.sub(r"[^A-Za-z0-9.-]", "-",
+                                         f"{name}-{p['name']}")
             packages.append({
                 "SPDXID": spdxid,
                 "name": p["name"],
@@ -212,9 +231,9 @@ def matchable(doc: Path) -> int:
     )
 
 
-def run_grype(doc: Path):
+def run_grype(engine: str, doc: Path):
     DB_CACHE.mkdir(parents=True, exist_ok=True)
-    return docker([
+    return container(engine, [
         "--tmpfs", "/tmp:rw,mode=1777,size=64m",
         "-v", f"{doc.parent}:/w:ro",
         "-v", f"{DB_CACHE}:/db",
@@ -240,20 +259,31 @@ def check() -> int:
               "cross-reference against; `just cve-build` writes both")
         return 0
 
-    if shutil.which("docker") is None:
-        return refuse("docker is not on PATH, so no scan ran")
+    # The stamp both filenames carry is what says one build produced both. A
+    # plain `just build` after an audit build refreshes the SBOM and leaves the
+    # manifest where it was, and cross-referencing that pair would quietly
+    # report every CVE fixed since the audit as something cve-check never saw.
+    build_id = archive.name[:-len(ARCHIVE_SUFFIX)]
+    if manifest.name[:-len(MANIFEST_SUFFIX)] != build_id:
+        return refuse(f"{archive.name} and {manifest.name} are from different "
+                      "builds, so the manifest does not describe what was "
+                      "scanned; re-run `just cve-build`")
+
+    engine = runtime()
+    if engine is None:
+        return refuse(f"none of {', '.join(RUNTIMES)} is on PATH, so no scan ran")
 
     with tempfile.TemporaryDirectory(dir=deploy.parents[2]) as scratch:
         work = Path(scratch)
         bundle = work / "bundle"
         bundle.mkdir()
 
-        unpacked = unpack(archive, bundle)
+        unpacked = unpack(engine, archive, bundle)
         if unpacked.returncode != 0:
             return refuse(f"unpacking {archive.name} in {UNPACK_IMAGE} failed "
                           f"({unpacked.returncode}): {tail(unpacked.stderr)}")
 
-        image_doc = bundle / (archive.name[:-len(".spdx.tar.zst")] + ".spdx.json")
+        image_doc = bundle / (build_id + ".spdx.json")
         if not image_doc.exists():
             return refuse(f"{archive.name} holds no {image_doc.name}, so the "
                           "image closure cannot be walked")
@@ -268,7 +298,7 @@ def check() -> int:
                 f'"{CPE_REF}" reference, so Grype would match nothing and '
                 "report a clean scan")
 
-        scan = run_grype(merged)
+        scan = run_grype(engine, merged)
         if scan.returncode != 0:
             return refuse(f"{GRYPE_IMAGE} failed ({scan.returncode}): "
                           f"{tail(scan.stderr)}")
@@ -278,6 +308,16 @@ def check() -> int:
             return refuse(f"{GRYPE_IMAGE} returned unreadable JSON: {exc}")
 
     matches = result.get("matches", [])
+
+    # The same silent failure as an unreadable CPE, one layer downstream: a
+    # reader that stops ingesting SPDX 2.2 returns a well-formed empty result,
+    # which is indistinguishable from an image with nothing wrong with it.
+    # Every package carrying a CPE and not one match is not a clean scan.
+    if not matches:
+        return refuse(f"{GRYPE_IMAGE} matched nothing against {with_cpe} "
+                      "packages that carry a CPE, which is not a result this "
+                      "image can produce")
+
     known = known_pairs(manifest.read_text(errors="replace"))
     delta = [m for m in matches
              if (m["artifact"]["name"], m["vulnerability"]["id"]) not in known]
@@ -296,7 +336,8 @@ def check() -> int:
           f"{with_cpe} packages")
     print(f"SBOM:     {archive.relative_to(top)} (built {built})")
     print(f"manifest: {manifest.relative_to(top)}")
-    print(f"scanner:  {GRYPE_IMAGE}, database as cached in {DB_CACHE}")
+    print(f"scanner:  {GRYPE_IMAGE} under {engine}, "
+          f"database as cached in {DB_CACHE_SHOWN}")
     print("A CVE_STATUS-blind second opinion: Grype cannot see the Patched and "
           "Ignored judgements cve-check records, so `just cve` stays "
           "authoritative and this is a supplement to it.")

--- a/tools/cve-scan.py
+++ b/tools/cve-scan.py
@@ -35,9 +35,6 @@ MANIFEST_SUFFIX = ".cve"
 GRYPE_IMAGE = "anchore/grype:v0.118.0"
 UNPACK_IMAGE = "ghcr.io/siemens/kas/kas:5.4"
 
-# kas-container supports either, so the scan must not require one of them.
-RUNTIMES = ("docker", "podman")
-
 # Kept out of build/ and out of the repository: the database only grows, and a
 # tmpfs will not hold it. Spelled home-relative so no username is printed.
 DB_CACHE_SHOWN = "~/.cache/grype"
@@ -114,24 +111,19 @@ def known_pairs(text):
     return pairs
 
 
-def runtime():
-    """Whichever container runtime is installed, preferring the first listed."""
-    return next((r for r in RUNTIMES if shutil.which(r)), None)
-
-
-def container(engine: str, args):
+def docker(args):
     """A pinned container, run as the invoking user.
 
     Grype's cache is unusable to a non-root run once a root run has written it,
     so every invocation here passes --user and none of them may drop it."""
     return subprocess.run(
-        [engine, "run", "--rm", "--user", f"{os.getuid()}:{os.getgid()}"] + args,
+        ["docker", "run", "--rm", "--user", f"{os.getuid()}:{os.getgid()}"] + args,
         capture_output=True, text=True)
 
 
-def unpack(engine: str, archive: Path, dest: Path):
+def unpack(archive: Path, dest: Path):
     """Extract the SPDX bundle without requiring zstd on the host."""
-    return container(engine, [
+    return docker([
         "-v", f"{archive.parent}:/in:ro",
         "-v", f"{dest}:/out",
         "--entrypoint", "tar", UNPACK_IMAGE,
@@ -231,9 +223,9 @@ def matchable(doc: Path) -> int:
     )
 
 
-def run_grype(engine: str, doc: Path):
+def run_grype(doc: Path):
     DB_CACHE.mkdir(parents=True, exist_ok=True)
-    return container(engine, [
+    return docker([
         "--tmpfs", "/tmp:rw,mode=1777,size=64m",
         "-v", f"{doc.parent}:/w:ro",
         "-v", f"{DB_CACHE}:/db",
@@ -269,16 +261,15 @@ def check() -> int:
                       "builds, so the manifest does not describe what was "
                       "scanned; re-run `just cve-build`")
 
-    engine = runtime()
-    if engine is None:
-        return refuse(f"none of {', '.join(RUNTIMES)} is on PATH, so no scan ran")
+    if shutil.which("docker") is None:
+        return refuse("docker is not on PATH, so no scan ran")
 
     with tempfile.TemporaryDirectory(dir=deploy.parents[2]) as scratch:
         work = Path(scratch)
         bundle = work / "bundle"
         bundle.mkdir()
 
-        unpacked = unpack(engine, archive, bundle)
+        unpacked = unpack(archive, bundle)
         if unpacked.returncode != 0:
             return refuse(f"unpacking {archive.name} in {UNPACK_IMAGE} failed "
                           f"({unpacked.returncode}): {tail(unpacked.stderr)}")
@@ -298,7 +289,7 @@ def check() -> int:
                 f'"{CPE_REF}" reference, so Grype would match nothing and '
                 "report a clean scan")
 
-        scan = run_grype(engine, merged)
+        scan = run_grype(merged)
         if scan.returncode != 0:
             return refuse(f"{GRYPE_IMAGE} failed ({scan.returncode}): "
                           f"{tail(scan.stderr)}")
@@ -336,8 +327,7 @@ def check() -> int:
           f"{with_cpe} packages")
     print(f"SBOM:     {archive.relative_to(top)} (built {built})")
     print(f"manifest: {manifest.relative_to(top)}")
-    print(f"scanner:  {GRYPE_IMAGE} under {engine}, "
-          f"database as cached in {DB_CACHE_SHOWN}")
+    print(f"scanner:  {GRYPE_IMAGE}, database as cached in {DB_CACHE_SHOWN}")
     print("A CVE_STATUS-blind second opinion: Grype cannot see the Patched and "
           "Ignored judgements cve-check records, so `just cve` stays "
           "authoritative and this is a supplement to it.")

--- a/tools/cve-scan.py
+++ b/tools/cve-scan.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Cross-check the image SBOM against a second vulnerability source.
+
+    cve-scan.py check    -- CVEs Grype reports that the cve-check manifest does not
+
+Grype cannot read CVE_STATUS, so this supplements `just cve` rather than
+replacing it. Both artifacts come from `just cve-build`. See docs/cve-and-sbom.md.
+"""
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+# tmp-<machine>, not tmp/: TMPDIR is ${TOPDIR}/tmp-${MACHINE}. The archive exists
+# twice -- timestamped and symlinked -- so both are resolved and de-duplicated.
+ARCHIVE_GLOB = "build/tmp-*/deploy/images/*/*.spdx.tar.zst"
+
+# Read from the SBOM's own deploy directory: the two artifacts must describe one
+# build, which a second repository-wide glob would not guarantee.
+MANIFEST_GLOB = "*.cve"
+
+# Both pinned. The scanner image is distroless -- no shell, no tar, no zstd -- so
+# the unpack runs in the image that already builds this tree; see README
+# "Quick start" for the kas pin it belongs to.
+GRYPE_IMAGE = "anchore/grype:v0.118.0"
+UNPACK_IMAGE = "ghcr.io/siemens/kas/kas:5.4"
+
+# Grype's v6 database unpacks to ~1.9 GB, which a tmpfs will not hold.
+DB_CACHE = Path.home() / ".cache" / "grype"
+
+# create-spdx writes the long URI form of this and syft's decoder matches only
+# the short one, dropping the CPE without saying so. See docs/cve-and-sbom.md.
+CPE_REF = "cpe23Type"
+
+# The document each hop names, as an SPDX external document reference.
+IMAGE_TO_PACKAGE = "CONTAINS"
+PACKAGE_TO_RECIPE = "GENERATED_FROM"
+DOC_REF = "DocumentRef-"
+RECIPE_REF = "DocumentRef-recipe-"
+RECIPE_ID = "SPDXRef-Recipe-"
+
+# Manifest records open with this key; the fields after it are order-independent.
+RECORD_START = "LAYER"
+PACKAGE = "PACKAGE NAME"
+CVE = "CVE"
+
+# `KEY: value`; the value may hold colons (MORE INFORMATION is a URL).
+FIELD = re.compile(r"^([A-Z][A-Za-z0-9 ]*):[ ]?(.*)$")
+
+
+def repo_top() -> Path:
+    return Path(subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                               capture_output=True, text=True,
+                               check=True).stdout.strip())
+
+
+def newest(top: Path, pattern: str):
+    """The most recently written match for a glob, or None.
+
+    By mtime, resolved and de-duplicated. deploy/ is not clamped to
+    SOURCE_DATE_EPOCH the way the rootfs is, so a file's own timestamp is the
+    build that wrote it. A resolved path that does not exist is a pruned symlink
+    target, and is skipped rather than stat'ed."""
+    unique = {p.resolve() for p in top.glob(pattern)}
+    found = sorted((p for p in unique if p.exists()),
+                   key=lambda p: p.stat().st_mtime, reverse=True)
+    return found[0] if found else None
+
+
+def refuse(message: str) -> int:
+    print(f"{message} -- refusing to report a pass", file=sys.stderr)
+    return 2
+
+
+def tail(stream: str, lines: int = 3) -> str:
+    return " / ".join(stream.strip().splitlines()[-lines:]) or "(no output)"
+
+
+def known_pairs(text):
+    """Every (package, CVE) the manifest already reports, whatever its status.
+
+    Split on the LAYER key rather than on blank lines: CVE SUMMARY is free NVD
+    prose and may carry one. Status is not read -- a CVE that cve-check called
+    Patched or Ignored is still one it knows about, and re-reporting it is the
+    noise this cross-check exists to remove."""
+    pairs = set()
+    package = None
+    for line in text.splitlines():
+        m = FIELD.match(line)
+        if not m:
+            continue
+        key, value = m.group(1), m.group(2)
+        if key == RECORD_START:
+            package = None
+        elif key == PACKAGE:
+            package = value
+        elif key == CVE and package is not None:
+            pairs.add((package, value))
+    return pairs
+
+
+def docker(args):
+    """A pinned container, run as the invoking user.
+
+    Grype's cache is unusable to a non-root run once a root run has written it,
+    so every invocation here passes --user and none of them may drop it."""
+    return subprocess.run(
+        ["docker", "run", "--rm", "--user", f"{os.getuid()}:{os.getgid()}"] + args,
+        capture_output=True, text=True)
+
+
+def unpack(archive: Path, dest: Path):
+    """Extract the SPDX bundle without requiring zstd on the host."""
+    return docker([
+        "-v", f"{archive.parent}:/in:ro",
+        "-v", f"{dest}:/out",
+        "--entrypoint", "tar", UNPACK_IMAGE,
+        "--use-compress-program=zstd", "-xf", f"/in/{archive.name}", "-C", "/out",
+    ])
+
+
+def image_closure(bundle: Path, image_doc: Path):
+    """One SPDX document holding every recipe the image installs.
+
+    Grype takes a single file and does not follow externalDocumentRefs, so the
+    bundle's 4,000-odd documents have to be walked here and merged: the image
+    document names the binary packages it contains, and each of those names the
+    recipe it was generated from. Selecting on a -native/-cross name suffix
+    instead over-reports, because a native build of a shipped recipe is a
+    separate document with the same CPE."""
+    image = json.loads(image_doc.read_text())
+    package_docs = {
+        r["relatedSpdxElement"].split(":")[0][len(DOC_REF):]
+        for r in image.get("relationships", [])
+        if r.get("relationshipType") == IMAGE_TO_PACKAGE
+        and r.get("relatedSpdxElement", "").startswith(DOC_REF)
+    }
+
+    recipe_docs = set()
+    for name in sorted(package_docs):
+        doc = bundle / f"{name}.spdx.json"
+        if not doc.exists():
+            continue
+        for r in json.loads(doc.read_text()).get("relationships", []):
+            if r.get("relationshipType") != PACKAGE_TO_RECIPE:
+                continue
+            ref = r.get("relatedSpdxElement", "").split(":")[0]
+            if ref.startswith(RECIPE_REF):
+                recipe_docs.add(ref[len(DOC_REF):])
+
+    packages, relationships = [], []
+    for name in sorted(recipe_docs):
+        doc = bundle / f"{name}.spdx.json"
+        if not doc.exists():
+            continue
+        for p in json.loads(doc.read_text()).get("packages", []):
+            if not p.get("SPDXID", "").startswith(RECIPE_ID):
+                continue
+            refs = [r for r in (p.get("externalRefs") or [])
+                    if CPE_REF in r.get("referenceType", "")]
+            if not refs:
+                continue
+            for r in refs:
+                r["referenceType"] = CPE_REF
+            spdxid = "SPDXRef-" + re.sub(r"[^A-Za-z0-9.-]", "-", name)
+            packages.append({
+                "SPDXID": spdxid,
+                "name": p["name"],
+                "versionInfo": p.get("versionInfo", "NOASSERTION"),
+                "downloadLocation": "NOASSERTION",
+                "copyrightText": "NOASSERTION",
+                "licenseConcluded": "NOASSERTION",
+                "licenseDeclared": "NOASSERTION",
+                "filesAnalyzed": False,
+                "externalRefs": refs,
+            })
+            relationships.append({
+                "spdxElementId": "SPDXRef-DOCUMENT",
+                "relationshipType": "DESCRIBES",
+                "relatedSpdxElement": spdxid,
+            })
+
+    return {
+        "spdxVersion": "SPDX-2.2",
+        "dataLicense": "CC0-1.0",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": "image-closure",
+        "documentNamespace": f"http://spdx.org/spdxdocs/image-closure/{image_doc.stem}",
+        "creationInfo": {
+            "created": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "creators": ["Tool: cve-scan.py"],
+        },
+        "packages": packages,
+        "relationships": relationships,
+    }
+
+
+def matchable(doc: Path) -> int:
+    """Packages in the written document carrying a CPE that Grype will read.
+
+    Counted from the file the container is about to be handed, not from the
+    structure that built it: a CPE left in create-spdx's long-URI form is
+    dropped in silence, and a scan of nothing exits 0 looking like a clean one."""
+    return sum(
+        1 for p in json.loads(doc.read_text()).get("packages", [])
+        if any(r.get("referenceType") == CPE_REF for r in p.get("externalRefs", []))
+    )
+
+
+def run_grype(doc: Path):
+    DB_CACHE.mkdir(parents=True, exist_ok=True)
+    return docker([
+        "--tmpfs", "/tmp:rw,mode=1777,size=64m",
+        "-v", f"{doc.parent}:/w:ro",
+        "-v", f"{DB_CACHE}:/db",
+        "-e", "TMPDIR=/db", "-e", "GRYPE_DB_CACHE_DIR=/db", "-e", "HOME=/db",
+        GRYPE_IMAGE, "-o", "json", f"/w/{doc.name}",
+    ])
+
+
+def check() -> int:
+    top = repo_top()
+    archive = newest(top, ARCHIVE_GLOB)
+    if archive is None:
+        # Both artifacts are opt-in, so their absence is a workflow state.
+        print(f"SKIPPED: no SPDX archive under {ARCHIVE_GLOB} "
+              "-- `just cve-build` writes it")
+        return 0
+
+    deploy = archive.parent
+    manifest = newest(deploy, MANIFEST_GLOB)
+    if manifest is None:
+        print(f"SKIPPED: SPDX archive at {archive.relative_to(top)} but no CVE "
+              f"manifest ({MANIFEST_GLOB}) beside it -- there is nothing to "
+              "cross-reference against; `just cve-build` writes both")
+        return 0
+
+    if shutil.which("docker") is None:
+        return refuse("docker is not on PATH, so no scan ran")
+
+    with tempfile.TemporaryDirectory(dir=deploy.parents[2]) as scratch:
+        work = Path(scratch)
+        bundle = work / "bundle"
+        bundle.mkdir()
+
+        unpacked = unpack(archive, bundle)
+        if unpacked.returncode != 0:
+            return refuse(f"unpacking {archive.name} in {UNPACK_IMAGE} failed "
+                          f"({unpacked.returncode}): {tail(unpacked.stderr)}")
+
+        image_doc = bundle / (archive.name[:-len(".spdx.tar.zst")] + ".spdx.json")
+        if not image_doc.exists():
+            return refuse(f"{archive.name} holds no {image_doc.name}, so the "
+                          "image closure cannot be walked")
+
+        merged = work / "image-closure.spdx.json"
+        merged.write_text(json.dumps(image_closure(bundle, image_doc)))
+
+        with_cpe = matchable(merged)
+        if with_cpe == 0:
+            return refuse(
+                f"no package in the merged document carries a "
+                f'"{CPE_REF}" reference, so Grype would match nothing and '
+                "report a clean scan")
+
+        scan = run_grype(merged)
+        if scan.returncode != 0:
+            return refuse(f"{GRYPE_IMAGE} failed ({scan.returncode}): "
+                          f"{tail(scan.stderr)}")
+        try:
+            result = json.loads(scan.stdout)
+        except json.JSONDecodeError as exc:
+            return refuse(f"{GRYPE_IMAGE} returned unreadable JSON: {exc}")
+
+    matches = result.get("matches", [])
+    known = known_pairs(manifest.read_text(errors="replace"))
+    delta = [m for m in matches
+             if (m["artifact"]["name"], m["vulnerability"]["id"]) not in known]
+
+    for m in sorted(delta, key=lambda m: (m["artifact"]["name"],
+                                          m["vulnerability"]["id"])):
+        art, vuln = m["artifact"], m["vulnerability"]
+        print(f"{art['name']} {art.get('version', '?')}  {vuln['id']}  "
+              f"{vuln.get('severity', '?')}  "
+              f"[{(vuln.get('fix') or {}).get('state') or 'unknown'}]")
+
+    packages = {m["artifact"]["name"] for m in delta}
+    built = datetime.fromtimestamp(archive.stat().st_mtime).strftime("%Y-%m-%d %H:%M")
+    print(f"\n{len(delta)} findings across {len(packages)} packages that the CVE "
+          f"manifest does not report, from {len(matches)} Grype matches over "
+          f"{with_cpe} packages")
+    print(f"SBOM:     {archive.relative_to(top)} (built {built})")
+    print(f"manifest: {manifest.relative_to(top)}")
+    print(f"scanner:  {GRYPE_IMAGE}, database as cached in {DB_CACHE}")
+    print("A CVE_STATUS-blind second opinion: Grype cannot see the Patched and "
+          "Ignored judgements cve-check records, so `just cve` stays "
+          "authoritative and this is a supplement to it.")
+
+    # Reports, never gates: exit 0 with findings. A nonzero exit is reserved for
+    # a report that cannot be trusted. See docs/cve-and-sbom.md.
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) == 2 and sys.argv[1] == "check":
+        return check()
+    print(__doc__.strip().split("\n\n")[1], file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #70.

Epic #61 image CVE scanning and SBOM, leg B. Adds `just cve-scan`: a one-shot local scan that merges the image closure out of the SPDX bundle Leg A pinned, scans it with a pinned Grype, and reports only the `(package, CVE)` pairs the `cve-check` manifest does not already carry — so `just cve` stays authoritative and this is a CVE_STATUS-blind second opinion beside it, not a replacement.

Validation run posted as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179NRssUKV1Y2p95MWvZb2X