### PR TITLE
#71 CVE delta-triage: persist audit manifests, diff newest vs previous

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -160,10 +160,16 @@ cve-scan:
     python3 tools/cve-scan.py check
 
 [group('audit')]
+[doc("Report what changed in the CVE picture since the previous audit build (skips if <2)")]
+cve-delta:
+    python3 tools/cve-delta.py check
+
+[group('audit')]
 [doc("Build with cve-check inherited, writing a CVE manifest beside the image")]
 cve-build:
     tools/write-build-rev.sh
     kas-container build {{config}}:includes/cve-audit.yaml
+    python3 tools/cve-delta.py snapshot
 
 # Write per-site config to a device's /data. The image carries none of it.
 [group('provision')]

--- a/Justfile
+++ b/Justfile
@@ -165,7 +165,7 @@ cve-delta:
     python3 tools/cve-delta.py check
 
 [group('audit')]
-[doc("Build with cve-check inherited, writing a CVE manifest beside the image")]
+[doc("Build with cve-check inherited: CVE manifest beside the image, snapshot in ~/.cache/wisekiosk")]
 cve-build:
     tools/write-build-rev.sh
     kas-container build {{config}}:includes/cve-audit.yaml

--- a/docs/cve-and-sbom.md
+++ b/docs/cve-and-sbom.md
@@ -254,7 +254,12 @@ The two artifacts' version strings are not comparable *to each other*. The CVE m
 git-versioned recipe — `glibc` reads `2.39+git` where `libc6` reads `2.39+git0+be1e627cd7-r1` — and
 spells an epoch with an underscore, `1_255.21` against the image manifest's `1:255.21-r0`. Only
 snapshot-against-snapshot comparisons within one artifact are apples to apples, and those are the
-only comparisons made.
+only comparisons made. A package whose same-named binary package enters or leaves the image between
+two snapshots therefore has no comparison available at all — its version is read from one artifact in
+one snapshot and from the other in the next — so it reads `feed` even where the version genuinely
+moved, as `bash` going 5.2.21 to 5.3 while the `bash` package is dropped would. That direction is
+deliberate: the label declines the comparison rather than manufacture a software regression out of a
+difference in spelling.
 
 A source-revision bump on a recipe whose binary package has a different name is therefore invisible.
 The truncated version does not change, the image manifest holds no entry under the recipe's name,

--- a/docs/cve-and-sbom.md
+++ b/docs/cve-and-sbom.md
@@ -248,7 +248,7 @@ carrying a record in at least one of the two snapshots. Reading only the image m
 the majority of findings with no version to compare, and report a `glibc` or a `curl` bump as NVD
 knowledge moving.
 
-Two limits follow from that, and both fail towards `feed`.
+Three limits follow from that, and all of them fail towards `feed`.
 
 The two artifacts' version strings are not comparable *to each other*. The CVE manifest truncates a
 git-versioned recipe — `glibc` reads `2.39+git` where `libc6` reads `2.39+git0+be1e627cd7-r1` — and
@@ -260,6 +260,12 @@ A source-revision bump on a recipe whose binary package has a different name is 
 The truncated version does not change, the image manifest holds no entry under the recipe's name,
 and a finding that moved because of that bump is labelled `feed`. The label reports what the two
 artifacts record about a package, not an independent judgement of what the software did.
+
+A `CVE_STATUS` annotation is invisible for the same reason. Adding one to a recipe or bbappend flips
+a finding to *Patched* or *Ignored* without moving any version, so the status change is real and
+deliberate — a person's triage judgement, described under What CVE_STATUS means — while the label
+beside it reads `feed`. A status change with no version behind it is worth reading as a third thing:
+somebody in this repository decided something about that CVE.
 
 ### Where the history lives
 

--- a/docs/cve-and-sbom.md
+++ b/docs/cve-and-sbom.md
@@ -199,6 +199,83 @@ What exits clean is an empty *delta* — matches came back, and the manifest alr
 every one of them. That is a different state from having measured nothing, and the exit codes keep
 the two apart.
 
+## The delta between audit builds
+
+A manifest holding several thousand findings is not a triage list, and re-reading it whole after
+every audit build is not triage. What is actionable is what changed since the last one — and that
+needs the last one kept.
+
+```sh
+just cve-delta
+```
+
+[`tools/cve-delta.py`](../tools/cve-delta.py) keeps each audit build's manifest and reports the
+difference between the two most recent. `just cve-build` captures a snapshot as its final step, so
+the history fills as audit builds happen rather than by anyone remembering to save one. Reading it
+needs no build, like the rest of the audit group.
+
+A snapshot is keyed on the commit, machine and build stamp recorded in the `.testdata.json` sitting
+beside the manifest. That file is frozen with the build that wrote it, which
+`meta-wisekiosk/conf/build-rev.inc` is not: that one holds the commit being built and the next build
+overwrites it. A manifest whose siblings are missing, or whose testdata describes some other build,
+is refused rather than stored — a snapshot that cannot be traced to a commit is worse than no
+snapshot, because later it is indistinguishable from one that can.
+
+The report is three buckets — findings **added**, findings **removed**, and findings whose status
+**changed** — and every line carries a label saying why it moved.
+
+| Label | What moved |
+|---|---|
+| `software` | the package's version changed between the two builds |
+| `feed` | the package is identical; NVD's knowledge of it changed |
+
+That distinction is the whole point. The two are identical in a plain diff of the manifests and they
+call for opposite responses: a software delta is this repository's own doing, traceable to the
+commits between the two snapshots, while a feed delta is the outside world learning something new
+about an image that did not change. Unlabelled, a routine NVD refresh reads as a regression and a
+real regression reads as noise.
+
+### What the label can and cannot see
+
+The version a finding is judged against is read from two artifacts, because neither covers the
+findings alone. The image manifest lists installed *binary* packages and carries the package
+revision, so it sees a patch-only recipe bump. The CVE manifest is keyed by *recipe*, which is what
+a finding names. Those two name spaces mostly do not meet — `fribidi` ships as `libfribidi0`, `glibc`
+as `libc6`, and well under half of this image's CVE-bearing recipes have a binary package of their
+own name. So the image manifest is read where the names do meet and the CVE manifest's own
+`PACKAGE VERSION` everywhere else, which makes coverage complete: every finding names a recipe
+carrying a record in at least one of the two snapshots. Reading only the image manifest would leave
+the majority of findings with no version to compare, and report a `glibc` or a `curl` bump as NVD
+knowledge moving.
+
+Two limits follow from that, and both fail towards `feed`.
+
+The two artifacts' version strings are not comparable *to each other*. The CVE manifest truncates a
+git-versioned recipe — `glibc` reads `2.39+git` where `libc6` reads `2.39+git0+be1e627cd7-r1` — and
+spells an epoch with an underscore, `1_255.21` against the image manifest's `1:255.21-r0`. Only
+snapshot-against-snapshot comparisons within one artifact are apples to apples, and those are the
+only comparisons made.
+
+A source-revision bump on a recipe whose binary package has a different name is therefore invisible.
+The truncated version does not change, the image manifest holds no entry under the recipe's name,
+and a finding that moved because of that bump is labelled `feed`. The label reports what the two
+artifacts record about a package, not an independent judgement of what the software did.
+
+### Where the history lives
+
+Snapshots go under `~/.cache/wisekiosk/cve-history/<machine>/<stamp>-<commit>/`, outside the
+repository and outside `build/`, which `just clean` empties. Each holds the CVE manifest, the image
+manifest and a small `snapshot.json` naming the commit. Nothing prunes them, on the same terms as
+the Grype database above: they only grow, and a delta is worth no more than the history behind it.
+
+One machine's snapshots are one series. A different `MACHINE` builds a different package set, so a
+diff across two of them would report the machine rather than the delta.
+
+Below two snapshots there is nothing to diff. The report says which case it is — no history at all,
+or one snapshot waiting on the next audit build — and exits clean, the way the rest of the audit
+group skips. A snapshot that is present but missing one of its files is refused instead: a delta
+computed over half a build would read exactly like a quiet one.
+
 ## The NVD database fetch
 
 `cve-check` needs NVD's data locally, and BitBake fetches it through NVD's public API. Unkeyed, that
@@ -249,4 +326,4 @@ The consequence to hold onto is that a scan happens when somebody runs one. Noth
 last audit build was months ago, and a stale manifest reads exactly like a fresh one, which is why
 both report scripts print the artifact's build time beside their counts. Closing that gap — a
 scheduled scan, a currency requirement, a threshold that can fail — is the rest of epic #61 image CVE
-scanning and SBOM, of which this baseline is the first leg.
+scanning and SBOM.

--- a/tools/cve-delta.py
+++ b/tools/cve-delta.py
@@ -132,10 +132,12 @@ def snapshot() -> int:
     prefix = manifest.name[:-len(MANIFEST_SUFFIX)]
     testdata = manifest.parent / (prefix + TESTDATA_SUFFIX)
     packages = manifest.parent / (prefix + PACKAGES_SUFFIX)
-    absent = [p.name for p in (testdata, packages) if not p.is_file()]
-    if absent:
-        return refuse(f"{manifest.name} has no {' and no '.join(absent)} beside "
-                      "it, so the snapshot could not be traced to a commit")
+    if not testdata.is_file():
+        return refuse(f"{manifest.name} has no {testdata.name} beside it, so "
+                      "the snapshot could not be traced to a commit")
+    if not packages.is_file():
+        return refuse(f"{manifest.name} has no {packages.name} beside it, so "
+                      "the delta's version label could not be computed")
 
     try:
         build = json.loads(testdata.read_text())
@@ -190,20 +192,39 @@ def findings(text):
 
 
 def package_versions(cve_text: str, packages_text: str):
-    """What each package was at, for deciding whether the software moved.
+    """What each package was at, as (source, version).
 
     Two sources, because neither covers the findings alone. The image manifest
     lists installed binary packages and carries the PR, so it sees a patch-only
     recipe bump; the CVE manifest is keyed by recipe, which is what a finding
     names, and most recipes have no binary package of the same name. The
-    manifest wins where the two meet. Version strings are only ever compared
-    across snapshots of the same source, never between the two."""
-    versions = {r[PACKAGE]: r.get(VERSION, "")
+    manifest wins where the two meet.
+
+    The source is carried rather than dropped so that moved() can refuse a
+    comparison between the two: their version strings are not comparable, and a
+    package that changes source between snapshots would otherwise differ on
+    spelling alone."""
+    versions = {r[PACKAGE]: (SNAP_MANIFEST, r.get(VERSION, ""))
                 for r in records(cve_text) if r.get(PACKAGE)}
-    versions.update({f[0]: f[2] for f in
+    versions.update({f[0]: (SNAP_PACKAGES, f[2]) for f in
                      (line.split() for line in packages_text.splitlines())
                      if len(f) == 3})
     return versions
+
+
+def moved(was, now) -> bool:
+    """Whether a package's software moved between two snapshots.
+
+    Each argument is that snapshot's (source, version) for the package, or None
+    where the snapshot does not record it at all. Only two entries from the SAME
+    source are ever compared; a source that differs says the package entered or
+    left the image manifest, which is not a version comparison this can make, so
+    it falls to the feed side with the other two documented limits."""
+    if was is None or now is None:
+        return (was is None) != (now is None)
+    if was[0] != now[0]:
+        return False
+    return was[1] != now[1]
 
 
 def read_snapshot(snap: Path):
@@ -221,17 +242,13 @@ def read_snapshot(snap: Path):
 
 
 def check() -> int:
-    if not HISTORY.is_dir() or not subdirs(HISTORY):
-        print(f"SKIPPED: no CVE snapshots on record in {HISTORY_SHOWN} "
-              "-- `just cve-build` captures one")
-        return 0
-
     # One machine's history is one comparable series: a different MACHINE builds
     # a different package set, and diffing across the two reports the machine
     # rather than the delta. The newest snapshot picks which series to read.
-    machine = max(subdirs(HISTORY),
+    machines = subdirs(HISTORY) if HISTORY.is_dir() else []
+    machine = max(machines, default=None,
                   key=lambda m: max([s.name for s in subdirs(m)], default=""))
-    series = subdirs(machine)
+    series = subdirs(machine) if machine is not None else []
     if not series:
         print(f"SKIPPED: no CVE snapshots on record in {HISTORY_SHOWN} "
               "-- `just cve-build` captures one")
@@ -261,7 +278,7 @@ def check() -> int:
 
     labelled = [
         (kind, key, status,
-         SOFTWARE if was_versions.get(key[0]) != now_versions.get(key[0])
+         SOFTWARE if moved(was_versions.get(key[0]), now_versions.get(key[0]))
          else FEED)
         for kind, key, status in delta
     ]
@@ -274,7 +291,8 @@ def check() -> int:
     counts = {k: sum(1 for d in labelled if d[0] == k)
               for k in (ADDED, REMOVED, CHANGED)}
     software = sum(1 for d in labelled if d[3] == SOFTWARE)
-    print(f"\n{len(labelled)} changes since the previous audit build: "
+    print(f"\n{len(labelled)} change{'' if len(labelled) == 1 else 's'} since "
+          "the previous audit build: "
           f"{counts[ADDED]} added, {counts[REMOVED]} removed, "
           f"{counts[CHANGED]} status-changed; {software} software, "
           f"{len(labelled) - software} feed")

--- a/tools/cve-delta.py
+++ b/tools/cve-delta.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Diff the CVE manifest against the previous audit build's.
+
+    cve-delta.py snapshot   -- keep this build's manifest in the local history
+    cve-delta.py check      -- what changed since the previous audit build
+
+The manifest comes from `just cve-build`. See docs/cve-and-sbom.md.
+"""
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# tmp-<machine>, not tmp/: TMPDIR is ${TOPDIR}/tmp-${MACHINE}. Each artifact
+# exists twice -- timestamped and symlinked -- so both are resolved and
+# de-duplicated.
+MANIFEST_GLOB = "build/tmp-*/deploy/images/*/*.cve"
+
+# Siblings in the same deploy directory, sharing the IMAGE_NAME prefix.
+MANIFEST_SUFFIX = ".cve"
+TESTDATA_SUFFIX = ".testdata.json"
+PACKAGES_SUFFIX = ".manifest"
+
+# Read from the build's own testdata, not from conf/build-rev.inc: that file
+# holds HEAD now and a later build overwrites it, while these are frozen with
+# the build that wrote the manifest beside them.
+REV = "KIOSK_BUILDINFO_REV"
+MACHINE = "MACHINE"
+DATETIME = "DATETIME"
+IMAGE_NAME = "IMAGE_NAME"
+
+# Human-scannable only. DATETIME already separates two builds at one commit.
+SHORT_SHA = 7
+
+# Kept out of build/ and out of the repository, as ~/.cache/grype is: a purge
+# takes the build tree with it and this only grows. Spelled home-relative so no
+# username is printed.
+HISTORY_SHOWN = "~/.cache/wisekiosk/cve-history"
+HISTORY = Path(HISTORY_SHOWN).expanduser()
+
+# What one snapshot directory holds.
+SNAP_MANIFEST = "manifest.cve"
+SNAP_PACKAGES = "image.manifest"
+SNAP_META = "snapshot.json"
+
+# Manifest records open with this key; the fields after it are order-independent.
+RECORD_START = "LAYER"
+PACKAGE = "PACKAGE NAME"
+VERSION = "PACKAGE VERSION"
+CVE = "CVE"
+STATUS = "CVE STATUS"
+
+# `KEY: value`; the value may hold colons (MORE INFORMATION is a URL).
+FIELD = re.compile(r"^([A-Z][A-Za-z0-9 ]*):[ ]?(.*)$")
+
+# Why a finding moved: the package changed, or NVD's knowledge of an unchanged
+# package did.
+SOFTWARE = "software"
+FEED = "feed"
+
+ADDED = "added"
+REMOVED = "removed"
+CHANGED = "changed"
+
+
+def repo_top() -> Path:
+    return Path(subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                               capture_output=True, text=True,
+                               check=True).stdout.strip())
+
+
+def newest(top: Path, pattern: str):
+    """The most recently written match for a glob, or None.
+
+    By mtime, resolved and de-duplicated. deploy/ is not clamped to
+    SOURCE_DATE_EPOCH the way the rootfs is, so a file's own timestamp is the
+    build that wrote it. A resolved path that does not exist is a pruned symlink
+    target, and is skipped rather than stat'ed."""
+    unique = {p.resolve() for p in top.glob(pattern)}
+    found = sorted((p for p in unique if p.exists()),
+                   key=lambda p: p.stat().st_mtime, reverse=True)
+    return found[0] if found else None
+
+
+def refuse(message: str) -> int:
+    print(f"{message} -- refusing to report a pass", file=sys.stderr)
+    return 2
+
+
+def records(text):
+    """The manifest's `KEY: value` blocks, as dicts.
+
+    Split on the LAYER key, not on blank lines: CVE SUMMARY and CVE DESCRIPTION
+    are free NVD prose and may carry one."""
+    rec = None
+    for line in text.splitlines():
+        m = FIELD.match(line)
+        if not m:
+            continue
+        key, value = m.group(1), m.group(2)
+        if key == RECORD_START:
+            if rec is not None:
+                yield rec
+            rec = {}
+        if rec is None:
+            continue
+        rec[key] = value
+    if rec is not None:
+        yield rec
+
+
+def subdirs(parent: Path):
+    """Directories under a path, by name. Staging directories are hidden."""
+    return sorted((p for p in parent.iterdir()
+                   if p.is_dir() and not p.name.startswith(".")),
+                  key=lambda p: p.name)
+
+
+def snapshot() -> int:
+    top = repo_top()
+    manifest = newest(top, MANIFEST_GLOB)
+    if manifest is None:
+        # cve-check is opt-in, so no manifest is a workflow state, not a fault.
+        print(f"SKIPPED: no CVE manifest under {MANIFEST_GLOB} "
+              "-- `just cve-build` writes it")
+        return 0
+
+    prefix = manifest.name[:-len(MANIFEST_SUFFIX)]
+    testdata = manifest.parent / (prefix + TESTDATA_SUFFIX)
+    packages = manifest.parent / (prefix + PACKAGES_SUFFIX)
+    absent = [p.name for p in (testdata, packages) if not p.is_file()]
+    if absent:
+        return refuse(f"{manifest.name} has no {' and no '.join(absent)} beside "
+                      "it, so the snapshot could not be traced to a commit")
+
+    try:
+        build = json.loads(testdata.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        return refuse(f"{testdata.name} is unreadable ({exc}), so the snapshot "
+                      "could not be traced to a commit")
+
+    # The siblings were derived from the manifest's own name, so the filenames
+    # agree by construction; what is checked is the testdata's CONTENT against
+    # that name. A record describing a different build would date the snapshot
+    # and name its commit wrongly, and nothing downstream could tell.
+    if build.get(IMAGE_NAME) != prefix:
+        return refuse(f"{testdata.name} describes {build.get(IMAGE_NAME)!r} and "
+                      f"not {prefix!r}, so it is not this manifest's build")
+    unset = [k for k in (REV, MACHINE, DATETIME) if not build.get(k)]
+    if unset:
+        return refuse(f"{testdata.name} sets no {', '.join(unset)}, so the "
+                      "snapshot could not be traced to a commit")
+
+    commit, machine, stamp = build[REV], build[MACHINE], build[DATETIME]
+    dest = HISTORY / machine / f"{stamp}-{commit[:SHORT_SHA]}"
+    if dest.is_dir():
+        print(f"{dest.name} is already on record in {HISTORY_SHOWN}/{machine} "
+              "-- nothing to capture")
+        return 0
+
+    # Staged and renamed into place, so a directory that exists is a complete
+    # snapshot: the no-op above reads its presence as "already captured".
+    HISTORY.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(dir=HISTORY, prefix=".staging-"))
+    try:
+        shutil.copyfile(manifest, staging / SNAP_MANIFEST)
+        shutil.copyfile(packages, staging / SNAP_PACKAGES)
+        (staging / SNAP_META).write_text(json.dumps(
+            {"commit": commit, "machine": machine, "datetime": stamp},
+            indent=2) + "\n")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        os.replace(staging, dest)
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+    print(f"captured {dest.name} in {HISTORY_SHOWN}/{machine} "
+          f"(from {manifest.relative_to(top)})")
+    return 0
+
+
+def findings(text):
+    """Every (package, CVE) the manifest reports, mapped to its status."""
+    return {(r[PACKAGE], r[CVE]): r.get(STATUS, "")
+            for r in records(text) if r.get(PACKAGE) and r.get(CVE)}
+
+
+def package_versions(cve_text: str, packages_text: str):
+    """What each package was at, for deciding whether the software moved.
+
+    Two sources, because neither covers the findings alone. The image manifest
+    lists installed binary packages and carries the PR, so it sees a patch-only
+    recipe bump; the CVE manifest is keyed by recipe, which is what a finding
+    names, and most recipes have no binary package of the same name. The
+    manifest wins where the two meet. Version strings are only ever compared
+    across snapshots of the same source, never between the two."""
+    versions = {r[PACKAGE]: r.get(VERSION, "")
+                for r in records(cve_text) if r.get(PACKAGE)}
+    versions.update({f[0]: f[2] for f in
+                     (line.split() for line in packages_text.splitlines())
+                     if len(f) == 3})
+    return versions
+
+
+def read_snapshot(snap: Path):
+    """One snapshot's findings and package versions, or a refusal message."""
+    for name in (SNAP_MANIFEST, SNAP_PACKAGES):
+        if not (snap / name).is_file():
+            return None, (f"the snapshot {snap.name} holds no {name}, so the "
+                          "delta would be computed over half a build")
+    cve_text = (snap / SNAP_MANIFEST).read_text(errors="replace")
+    found = findings(cve_text)
+    if not found:
+        return None, (f"the snapshot {snap.name} holds no CVE records")
+    packages_text = (snap / SNAP_PACKAGES).read_text(errors="replace")
+    return (found, package_versions(cve_text, packages_text)), None
+
+
+def check() -> int:
+    if not HISTORY.is_dir() or not subdirs(HISTORY):
+        print(f"SKIPPED: no CVE snapshots on record in {HISTORY_SHOWN} "
+              "-- `just cve-build` captures one")
+        return 0
+
+    # One machine's history is one comparable series: a different MACHINE builds
+    # a different package set, and diffing across the two reports the machine
+    # rather than the delta. The newest snapshot picks which series to read.
+    machine = max(subdirs(HISTORY),
+                  key=lambda m: max([s.name for s in subdirs(m)], default=""))
+    series = subdirs(machine)
+    if not series:
+        print(f"SKIPPED: no CVE snapshots on record in {HISTORY_SHOWN} "
+              "-- `just cve-build` captures one")
+        return 0
+    if len(series) == 1:
+        print(f"SKIPPED: only one CVE snapshot on record ({series[0].name}); "
+              "nothing to diff until the next audit build.")
+        return 0
+
+    previous, latest = series[-2], series[-1]
+    read = {}
+    for snap in (previous, latest):
+        read[snap], why = read_snapshot(snap)
+        if why:
+            return refuse(why)
+    was, was_versions = read[previous]
+    now, now_versions = read[latest]
+
+    delta = []
+    for key in sorted(set(was) | set(now)):
+        if key not in was:
+            delta.append((ADDED, key, now[key]))
+        elif key not in now:
+            delta.append((REMOVED, key, was[key]))
+        elif was[key] != now[key]:
+            delta.append((CHANGED, key, f"{was[key]} -> {now[key]}"))
+
+    labelled = [
+        (kind, key, status,
+         SOFTWARE if was_versions.get(key[0]) != now_versions.get(key[0])
+         else FEED)
+        for kind, key, status in delta
+    ]
+
+    for wanted in (ADDED, REMOVED, CHANGED):
+        for kind, (package, cve), status, label in labelled:
+            if kind == wanted:
+                print(f"{kind}  {package}  {cve}  {status}  [{label}]")
+
+    counts = {k: sum(1 for d in labelled if d[0] == k)
+              for k in (ADDED, REMOVED, CHANGED)}
+    software = sum(1 for d in labelled if d[3] == SOFTWARE)
+    print(f"\n{len(labelled)} changes since the previous audit build: "
+          f"{counts[ADDED]} added, {counts[REMOVED]} removed, "
+          f"{counts[CHANGED]} status-changed; {software} software, "
+          f"{len(labelled) - software} feed")
+    print(f"newest:   {latest.name} ({len(now)} findings)")
+    print(f"previous: {previous.name} ({len(was)} findings)")
+    print(f"machine:  {machine.name}, history in {HISTORY_SHOWN}")
+
+    # Reports, never gates: exit 0 with findings. A nonzero exit is reserved for
+    # a report that cannot be trusted. See docs/cve-and-sbom.md.
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) == 2 and sys.argv[1] == "snapshot":
+        return snapshot()
+    if len(sys.argv) == 2 and sys.argv[1] == "check":
+        return check()
+    print(__doc__.strip().split("\n\n")[1], file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #71.

Leg C of epic #61 image CVE scanning and SBOM. An audit build's manifest carries several thousand
unpatched findings and ~94.5% of them are the RPi kernel; re-reading that list whole after every
audit build is not triage. What is actionable is **what changed since the last audit build** — and,
critically, *why* each thing changed.

Local to the one build box, per the owner's re-scope: delta-triage needs persistence, not transport.
No publish, no CI, no committed CVE history.

## What lands

**`tools/cve-delta.py`** — stdlib only, two verbs, in the `cve-report.py`/`cve-scan.py` family and
holding the same three outcomes (report at exit 0, loud `SKIPPED` at exit 0, refuse at exit 2).

- `snapshot` keeps a build's `.cve` and `.manifest` under `~/.cache/wisekiosk/cve-history/`, keyed on
  the commit, machine and build stamp recorded in the `.testdata.json` beside them — the only source
  provably co-temporal with the manifest, unlike `conf/build-rev.inc`, which holds the commit being
  built and is overwritten by the next build. Idempotent. Refuses to store a snapshot it cannot trace
  to a commit.
- `check` diffs the two newest snapshots for one machine into **added**, **removed** and
  **status-changed** findings, labelling each **software** (the package's version moved) or **feed**
  (the package is identical; NVD's knowledge of it moved). That label is the ticket's hard
  requirement: the two are identical in a plain diff and call for opposite responses.

**`Justfile`** — `just cve-delta` joins `[group('audit')]`; `just cve-build` captures a snapshot as
its final step, so the history fills as audit builds happen rather than by anyone remembering.

**`docs/cve-and-sbom.md`** — a new section covering the report, the labelling, where the history
lives and why it only grows, and the limits the label genuinely has.

## One design point worth a reviewer's attention

The approved plan specified the image manifest as the sole version source for the label. Measured
against the real artifacts, that is wrong: the `.cve` is keyed by **recipe** and the `.manifest`
lists installed **binary packages**, and only **37 of this image's 96** CVE-bearing recipes appear in
the manifest by name — **10 of the 19** recipes carrying an unpatched finding are absent entirely.
`fribidi` ships as `libfribidi0`, `glibc` as `libc6`. Read the plan's way, a real `glibc` or `curl`
bump would have been labelled *feed*, silently, in the direction that looks correct.

So the version map reads the image manifest where the names meet — it carries the package revision
and so sees a patch-only bump — and the CVE manifest's own `PACKAGE VERSION` everywhere else, which
makes coverage complete by construction. The two artifacts' version strings are never compared to
each other: the version carries its source, and a package recorded from different sources in the two
snapshots falls to *feed* rather than being compared across artifacts. Only snapshot-against-snapshot
comparisons within one artifact are made. The label's limits are documented as limits in the doc
section, not buried in comments.

## Verification and review

`just guards` and `just verify` green. `snapshot` and both skip states exercised against the real
on-disk audit build; the diff and label logic proved on a synthetic second snapshot with all three
buckets and both labels seeded, plus a counterfactual showing what the plan's original version source
would have mislabelled. Every refusal was watched failing and the valid-but-differently-spelled
variant watched passing. Full transcript in a comment below.

An independent review of the diff found one blocking defect — the version map originally discarded
each version's source, so a package present in one snapshot's `.manifest` but absent from the other's
was compared `.manifest`-string against `.cve`-string, mislabelling a feed delta as *software*. Fixed
by carrying the source with the version (`moved()` is now the sole label decision); the reviewer's
own reproduction now prints *feed*, and a second pass confirmed the invariant is enforced in code
with no regression. Three should-fix items landed with it; two follow-ups were filed (#78 PyYAML
provisioning, #79 image identity in the snapshot key).

A true two-*real*-build delta needs a second audit build at a different commit (~4.5 h) and is
deferred; the synthetic proof exercises the diff and label logic, the real snapshot exercises
capture, sibling pairing and commit provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179NRssUKV1Y2p95MWvZb2X
