### PR TITLE
#72 layer currency: detect pinned layers upstream has moved past

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ One owner per fact. Read the owner; do not restate it here or anywhere else.
 | Which commit a *running* image was built from | `/etc/buildinfo` on the device |
 | Replacing the RAUC signing key, and the order it must happen in | [`docs/rauc-key-rotation.md`](docs/rauc-key-rotation.md) |
 | Scanning the image for CVEs, reading the SBOM, and what `CVE_STATUS` means | [`docs/cve-and-sbom.md`](docs/cve-and-sbom.md) |
+| Whether the pinned upstream repos have fallen behind their branch heads | [`docs/layer-currency.md`](docs/layer-currency.md) |
 | What was tried, what it cost, what was rejected | [`docs/issue_investigation/`](docs/issue_investigation/TEMPLATE.md) |
 | The shape every investigation takes, and R1-R3 | [`docs/issue_investigation/TEMPLATE.md`](docs/issue_investigation/TEMPLATE.md) |
 | Site configuration — SSID, PSK hash, URL, hostname, machine-id | out-of-tree `~/.config/wisekiosk/secrets.yaml` |

--- a/Justfile
+++ b/Justfile
@@ -165,7 +165,7 @@ cve-delta:
     python3 tools/cve-delta.py check
 
 [group('audit')]
-[doc("Report which pinned upstream layers their branch head has moved past (needs network)")]
+[doc("Report which pinned upstream repos have fallen behind their branch head (needs network)")]
 currency:
     python3 tools/layer-currency.py check
 

--- a/Justfile
+++ b/Justfile
@@ -165,6 +165,11 @@ cve-delta:
     python3 tools/cve-delta.py check
 
 [group('audit')]
+[doc("Report which pinned upstream layers their branch head has moved past (needs network)")]
+currency:
+    python3 tools/layer-currency.py check
+
+[group('audit')]
 [doc("Build with cve-check inherited: CVE manifest beside the image, snapshot in ~/.cache/wisekiosk")]
 cve-build:
     tools/write-build-rev.sh

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ behind those changes are indexed in **[docs/README.md](docs/README.md)**.
 
 `kas-container` runs the build inside a container, so a working **Docker** is a
 prerequisite. The flash and OTA paths additionally need `git`, `debugfs` (`e2fsprogs`) and `openssl`,
-and the repository guards (`just guards` and the pre-commit hook) need **PyYAML** for `python3` to
-validate the kas YAML — all of them refuse rather than skip when one is missing. On an
+and the repository guards (`just guards` and the pre-commit hook) and `just currency` need **PyYAML**
+for `python3` to read the kas YAML — all of them refuse rather than skip when one is missing. On an
 externally-managed (PEP 668) `python3`, install PyYAML with a virtualenv, the distro's
 `python3-yaml`, or `python3 -m pip install --break-system-packages pyyaml`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 | [`layers-and-kas.md`](layers-and-kas.md) | How does a tree of YAML and recipes become an image, for someone who has not used Yocto — and which commit is a given image from? |
 | [`rauc-key-rotation.md`](rauc-key-rotation.md) | How do you replace the RAUC signing key the devices trust, and why must it happen in a fixed order? |
 | [`cve-and-sbom.md`](cve-and-sbom.md) | What is the image made of, which of those packages carry published vulnerabilities, and how do you find out? |
+| [`layer-currency.md`](layer-currency.md) | Has upstream moved past the commits the image's layers are pinned to, and what does knowing that not tell you? |
 | [`issue_investigation/TEMPLATE.md`](issue_investigation/TEMPLATE.md) | What shape must an issue investigation take, and what must every test run in it name? |
 | [`issue_investigation/boot_cpu_saturation/`](issue_investigation/boot_cpu_saturation/README.md) | Across a boot, is the single core doing work, waiting on hardware, or queued behind something else? |
 | [`issue_investigation/wlan0_udev_queue/`](issue_investigation/wlan0_udev_queue/README.md) | What occupies the gap between the WiFi chip appearing on the bus and `wlan0` existing, and what is removing it worth? |

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@
 | [`layers-and-kas.md`](layers-and-kas.md) | How does a tree of YAML and recipes become an image, for someone who has not used Yocto — and which commit is a given image from? |
 | [`rauc-key-rotation.md`](rauc-key-rotation.md) | How do you replace the RAUC signing key the devices trust, and why must it happen in a fixed order? |
 | [`cve-and-sbom.md`](cve-and-sbom.md) | What is the image made of, which of those packages carry published vulnerabilities, and how do you find out? |
-| [`layer-currency.md`](layer-currency.md) | Has upstream moved past the commits the image's layers are pinned to, and what does knowing that not tell you? |
+| [`layer-currency.md`](layer-currency.md) | Has upstream moved past the commits the image's repositories are pinned to, and what does knowing that not tell you? |
 | [`issue_investigation/TEMPLATE.md`](issue_investigation/TEMPLATE.md) | What shape must an issue investigation take, and what must every test run in it name? |
 | [`issue_investigation/boot_cpu_saturation/`](issue_investigation/boot_cpu_saturation/README.md) | Across a boot, is the single core doing work, waiting on hardware, or queued behind something else? |
 | [`issue_investigation/wlan0_udev_queue/`](issue_investigation/wlan0_udev_queue/README.md) | What occupies the gap between the WiFi chip appearing on the bus and `wlan0` existing, and what is removing it worth? |

--- a/docs/cve-and-sbom.md
+++ b/docs/cve-and-sbom.md
@@ -338,3 +338,8 @@ last audit build was months ago, and a stale manifest reads exactly like a fresh
 both report scripts print the artifact's build time beside their counts. Closing that gap — a
 scheduled scan, a currency requirement, a threshold that can fail — is the rest of epic #61 image CVE
 scanning and SBOM.
+
+A second staleness sits behind this one, and [`layer-currency.md`](layer-currency.md) covers it:
+whether upstream has moved past the commits the image's *layers* are pinned to. That question is
+about the sources a build would draw from rather than about what the last build found, so
+`just currency` answers it in seconds with no build at all.

--- a/docs/cve-and-sbom.md
+++ b/docs/cve-and-sbom.md
@@ -336,10 +336,9 @@ than no check at all: it reads green while measuring nothing.
 The consequence to hold onto is that a scan happens when somebody runs one. Nothing detects that the
 last audit build was months ago, and a stale manifest reads exactly like a fresh one, which is why
 both report scripts print the artifact's build time beside their counts. Closing that gap — a
-scheduled scan, a currency requirement, a threshold that can fail — is the rest of epic #61 image CVE
-scanning and SBOM.
+scheduled scan, a scan-freshness requirement, a threshold that can fail — is the rest of epic #61
+image CVE scanning and SBOM.
 
 A second staleness sits behind this one, and [`layer-currency.md`](layer-currency.md) covers it:
-whether upstream has moved past the commits the image's *layers* are pinned to. That question is
-about the sources a build would draw from rather than about what the last build found, so
-`just currency` answers it in seconds with no build at all.
+whether upstream has moved past the commits the image's *sources* are pinned to. That question is
+about what a build would draw from rather than about what the last build found.

--- a/docs/layer-currency.md
+++ b/docs/layer-currency.md
@@ -26,6 +26,11 @@ carrying a `repos:` block, and merges those blocks by name. A pin added to an ex
 include, or in a new one, is covered the day it lands with no change here. The report prints the
 files it read, so what it covered is on the page beside what it found.
 
+Two files describing one repository merge into a single entry, which is what lets `meta-autonomos` be
+pinned in one file and gain a layer in another. Two files giving that repository a *different* `url:`,
+`commit:` or `branch:` refuse instead: kas settles that by include-chain order, this does not read the
+chain, and guessing which pin wins is how a report comes back confident and wrong.
+
 ## Reading the output
 
 One line per pinned repository, `behind` first:
@@ -83,8 +88,9 @@ up until somebody decides otherwise.
 A report it cannot complete **refuses and exits 2**, printing why. That covers everything between the
 question and the answer: PyYAML absent, an include file that will not parse, a `commit:` that is
 missing or not a full object name, a pin with no `url:` to compare it against, no branch resolvable,
-an entry shaped in a way it does not recognise, and any `git ls-remote` that fails, stalls, or
-answers with a ref that is not the one asked for.
+one repository pinned two different ways across two files, an entry shaped in a way it does not
+recognise, and any `git ls-remote` that fails, stalls, or answers with a ref that is not the one
+asked for.
 
 There is no third outcome and no skipped state. A repository quietly dropped from the report would
 read exactly like one that is current, so nothing is ever dropped quietly.

--- a/docs/layer-currency.md
+++ b/docs/layer-currency.md
@@ -1,0 +1,85 @@
+# Layer currency
+
+This answers one question: **has upstream moved past the commits this image is pinned to?**
+
+The image is built from nine upstream layers, each frozen at a `commit:` in `includes/`. Pinning them
+is deliberate, for the reasons [`layers-and-kas.md`](layers-and-kas.md) §"Bumping the upstream pin"
+gives — but nothing about a pin expires. It sits at whatever a person last typed, and the branch it
+came from keeps moving without saying so. On a stable branch that movement is mostly backported
+fixes, so a pin left alone long enough is an image that is missing them.
+
+Dependabot cannot see this. It reads package manifests, and a kas `commit:` is not one;
+[`../.github/dependabot.yml`](../.github/dependabot.yml) says so itself. This check is the substitute.
+
+## Running it
+
+```sh
+just currency
+```
+
+[`../tools/layer-currency.py`](../tools/layer-currency.py) reads the pins out of the three files
+[`layers-and-kas.md`](layers-and-kas.md) §"Bumping the upstream pin" names, and asks each remote for
+the head of the branch that repo tracks. It needs network and nothing else — no build, no checkout,
+no `sources/` tree — and it takes a few seconds. The report prints the files it read, so what it
+covered is on the page beside what it found.
+
+The pins are read at run time rather than listed in the script. A tenth layer added to those files is
+covered the day it lands, with no change here.
+
+## Reading the output
+
+One line per pinned layer, `behind` first:
+
+```
+behind   poky  scarthgap (chain default)  <pinned sha> -> <head sha>  https://git.yoctoproject.org/git/poky
+current  meta-rauc  scarthgap  <pinned sha>  https://github.com/rauc/meta-rauc.git
+```
+
+**`current`** means the pin *is* the branch head. **`behind`** means the head has moved off it, and
+the two SHAs say from where to where.
+
+The branch is printed because most repos do not name one. Those inherit the chain default that
+`defaults.repos.branch` in `includes/base.yaml` sets, and a repo that took it is marked
+`(chain default)` — so a pin compared against the wrong branch is visible in the report rather than
+buried in the inference behind it. The repos that do name a branch are the ones tracking something
+other than the LTS release, and the report names it for them too.
+
+`meta-wisekiosk` is excluded and the report says so. It declares no `url:`, which is how kas spells
+"the repository holding this config file" — it is this repo, it carries no pin, and there is no
+upstream to ask.
+
+## What it cannot see
+
+**It compares SHAs, not ancestry.** `behind` says the head is not the pinned commit. It does not say
+the pin is an ancestor of that head, how many commits separate them, or what those commits contain.
+Establishing that needs a clone, which is the cost this check exists to avoid. A force-push or a
+rewritten branch produces the same `behind` as a hundred ordinary commits.
+
+**It says nothing about what being behind is worth.** A pin behind by one documentation commit and a
+pin behind by a quarter of security backports report identically. Reading the log between the two
+SHAs is the next step, and it is a person's, not this script's — the same division the CVE tooling
+keeps in [`cve-and-sbom.md`](cve-and-sbom.md) §"Reading the CVE report".
+
+**It needs network, and it is point-in-time.** Every run asks the remotes fresh; there is no cached
+answer and no offline mode. Nothing is stored between runs either, so this reports a *state* and
+never a delta — it cannot tell you that poky moved since you last looked, only where it is now.
+
+## Outcomes
+
+Two, and they are the ones the rest of the audit group holds to.
+
+A report **exits 0 whatever it finds**. Layers behind their branch head are findings, not failures:
+nothing here gates a build, a flash or a pull request, and a pin is behind on purpose right up until
+somebody decides otherwise.
+
+A report it cannot complete **refuses and exits 2**, printing why. That covers a pinned entry it
+cannot resolve — no `commit:`, a malformed one, no branch to compare against, a shape it does not
+recognise — and any `git ls-remote` that fails. There is no skipped state and no partial pass: a
+layer quietly dropped from the report would read exactly like a layer that is current.
+
+## When a pin is behind
+
+Bumping it is an ordinary reviewed edit to `includes/`, and
+[`layers-and-kas.md`](layers-and-kas.md) §"Bumping the upstream pin" is the procedure — including
+what to do when a carried patch stops applying, which is the failure mode a bump most often hits.
+This check finds the pins worth that work; it does not do it, and it never edits a file.

--- a/docs/layer-currency.md
+++ b/docs/layer-currency.md
@@ -22,7 +22,7 @@ branch that repo tracks. It needs network — no build, no checkout, no `sources
 a few seconds.
 
 Both the pins and the files holding them are found at run time: it scans `includes/` for YAML
-carrying a `repos:` block, and merges those blocks the way kas does. A pin added to an existing
+carrying a `repos:` block, and merges those blocks by name. A pin added to an existing
 include, or in a new one, is covered the day it lands with no change here. The report prints the
 files it read, so what it covered is on the page beside what it found.
 
@@ -31,8 +31,8 @@ files it read, so what it covered is on the page beside what it found.
 One line per pinned repository, `behind` first:
 
 ```
-behind   poky       scarthgap (chain default)  <pinned sha> -> <head sha>  https://git.yoctoproject.org/git/poky
-current  meta-rauc  scarthgap                  <pinned sha>               https://github.com/rauc/meta-rauc.git
+behind  poky  scarthgap (chain default)  <pinned sha> -> <head sha>  https://git.yoctoproject.org/git/poky
+current  meta-rauc  scarthgap  <pinned sha>  https://github.com/rauc/meta-rauc.git
 ```
 
 **`current`** means the pin *is* the branch head. **`behind`** means the head has moved off it, and

--- a/docs/layer-currency.md
+++ b/docs/layer-currency.md
@@ -2,7 +2,7 @@
 
 This answers one question: **has upstream moved past the commits this image is pinned to?**
 
-The image is built from nine upstream layers, each frozen at a `commit:` in `includes/`. Pinning them
+The image is built from upstream repositories, each frozen at a `commit:` in `includes/`. Pinning them
 is deliberate, for the reasons [`layers-and-kas.md`](layers-and-kas.md) §"Bumping the upstream pin"
 gives — but nothing about a pin expires. It sits at whatever a person last typed, and the branch it
 came from keeps moving without saying so. On a stable branch that movement is mostly backported
@@ -17,22 +17,22 @@ Dependabot cannot see this. It reads package manifests, and a kas `commit:` is n
 just currency
 ```
 
-[`../tools/layer-currency.py`](../tools/layer-currency.py) reads the pins out of the three files
-[`layers-and-kas.md`](layers-and-kas.md) §"Bumping the upstream pin" names, and asks each remote for
-the head of the branch that repo tracks. It needs network and nothing else — no build, no checkout,
-no `sources/` tree — and it takes a few seconds. The report prints the files it read, so what it
-covered is on the page beside what it found.
+[`../tools/layer-currency.py`](../tools/layer-currency.py) asks each remote for the head of the
+branch that repo tracks. It needs network — no build, no checkout, no `sources/` tree — and it takes
+a few seconds.
 
-The pins are read at run time rather than listed in the script. A tenth layer added to those files is
-covered the day it lands, with no change here.
+Both the pins and the files holding them are found at run time: it scans `includes/` for YAML
+carrying a `repos:` block, and merges those blocks the way kas does. A pin added to an existing
+include, or in a new one, is covered the day it lands with no change here. The report prints the
+files it read, so what it covered is on the page beside what it found.
 
 ## Reading the output
 
-One line per pinned layer, `behind` first:
+One line per pinned repository, `behind` first:
 
 ```
-behind   poky  scarthgap (chain default)  <pinned sha> -> <head sha>  https://git.yoctoproject.org/git/poky
-current  meta-rauc  scarthgap  <pinned sha>  https://github.com/rauc/meta-rauc.git
+behind   poky       scarthgap (chain default)  <pinned sha> -> <head sha>  https://git.yoctoproject.org/git/poky
+current  meta-rauc  scarthgap                  <pinned sha>               https://github.com/rauc/meta-rauc.git
 ```
 
 **`current`** means the pin *is* the branch head. **`behind`** means the head has moved off it, and
@@ -44,9 +44,10 @@ The branch is printed because most repos do not name one. Those inherit the chai
 buried in the inference behind it. The repos that do name a branch are the ones tracking something
 other than the LTS release, and the report names it for them too.
 
-`meta-wisekiosk` is excluded and the report says so. It declares no `url:`, which is how kas spells
-"the repository holding this config file" — it is this repo, it carries no pin, and there is no
-upstream to ask.
+`meta-wisekiosk` is excluded and the report says so. It declares neither a `url:` nor a `commit:`,
+which is how kas spells "the repository holding this config file" — it is this repo, it carries no
+pin, and there is no upstream to ask. An entry missing only one of the two is not that: a pin with no
+remote to compare it against is refused, so a dropped `url:` line cannot quietly shrink the report.
 
 ## What it cannot see
 
@@ -54,6 +55,13 @@ upstream to ask.
 the pin is an ancestor of that head, how many commits separate them, or what those commits contain.
 Establishing that needs a clone, which is the cost this check exists to avoid. A force-push or a
 rewritten branch produces the same `behind` as a hundred ordinary commits.
+
+**It compares pins, not recipe versions.** The unit here is the repository: a pinned SHA against a
+branch head. A repo sitting exactly on its head still carries whatever recipe versions that branch
+froze, and on an LTS branch those are deliberately old — so `current` on every line says the pins are
+fresh, not that the software in the image is. Answering the recipe question needs a configured build
+tree to query, which is the cost this check exists to avoid, and it is tracked separately as
+**#81 scoped `devtool check-upgrade-status` target**.
 
 **It says nothing about what being behind is worth.** A pin behind by one documentation commit and a
 pin behind by a quarter of security backports report identically. Reading the log between the two
@@ -68,18 +76,20 @@ never a delta — it cannot tell you that poky moved since you last looked, only
 
 Two, and they are the ones the rest of the audit group holds to.
 
-A report **exits 0 whatever it finds**. Layers behind their branch head are findings, not failures:
-nothing here gates a build, a flash or a pull request, and a pin is behind on purpose right up until
-somebody decides otherwise.
+A report **exits 0 whatever it finds**. Repositories behind their branch head are findings, not
+failures: nothing here gates a build, a flash or a pull request, and a pin is behind on purpose right
+up until somebody decides otherwise.
 
-A report it cannot complete **refuses and exits 2**, printing why. That covers a pinned entry it
-cannot resolve — no `commit:`, a malformed one, no branch to compare against, a shape it does not
-recognise — and any `git ls-remote` that fails. There is no skipped state and no partial pass: a
-layer quietly dropped from the report would read exactly like a layer that is current.
+A report it cannot complete **refuses and exits 2**, printing why. That covers everything between the
+question and the answer: PyYAML absent, an include file that will not parse, a `commit:` that is
+missing or not a full object name, a pin with no `url:` to compare it against, no branch resolvable,
+an entry shaped in a way it does not recognise, and any `git ls-remote` that fails, stalls, or
+answers with a ref that is not the one asked for.
+
+There is no third outcome and no skipped state. A repository quietly dropped from the report would
+read exactly like one that is current, so nothing is ever dropped quietly.
 
 ## When a pin is behind
 
-Bumping it is an ordinary reviewed edit to `includes/`, and
-[`layers-and-kas.md`](layers-and-kas.md) §"Bumping the upstream pin" is the procedure — including
-what to do when a carried patch stops applying, which is the failure mode a bump most often hits.
-This check finds the pins worth that work; it does not do it, and it never edits a file.
+[`layers-and-kas.md`](layers-and-kas.md) §"Bumping the upstream pin" is the procedure. This check
+finds the pins worth that work; it does not do it, and it never edits a file.

--- a/tools/layer-currency.py
+++ b/tools/layer-currency.py
@@ -22,6 +22,10 @@ except ImportError:
 INCLUDES = "includes"
 PIN_GLOBS = ("*.yaml", "*.yml")
 
+# What a repo entry is asked about. Two files setting one of these differently
+# is decided by kas on include-chain order, which is not visible from here.
+PIN_KEYS = ("url", "commit", "branch")
+
 # A full object name. A short or symbolic pin is not comparable against what
 # ls-remote returns, and comparing it would report `behind` on spelling alone.
 SHA = re.compile(r"^[0-9a-f]{40}$")
@@ -62,10 +66,11 @@ def load_pins(top: Path):
 
     Returns the entries merged by name -- a later file adding layers to a repo
     an earlier one pinned is one entry, not two -- with the branch an entry
-    declaring none inherits, and the files read. Merged in path order; where
-    two files set one repo's key that order decides it, which is not kas's
-    include-chain precedence. An entry that is not a mapping is carried through
-    unmerged, for check() to refuse rather than normalise."""
+    declaring none inherits, and the files read. Two files setting one repo's
+    url, commit or branch to different values refuse; setting it in one file
+    and not the other, or to the same value, merges. An entry that is not a
+    mapping is carried through unmerged, for check() to refuse rather than
+    normalise."""
     root = top / INCLUDES
     files = sorted({p for g in PIN_GLOBS for p in root.rglob(g)}) \
         if root.is_dir() else []
@@ -73,7 +78,7 @@ def load_pins(top: Path):
         return None, (f"{INCLUDES}/ holds no YAML file, so no pin could be "
                       "read")
 
-    repos, pin_files, defaults = {}, [], {}
+    repos, pin_files, defaults, pinned = {}, [], {}, {}
     for path in files:
         rel = path.relative_to(top).as_posix()
         try:
@@ -91,10 +96,25 @@ def load_pins(top: Path):
         pin_files.append(rel)
         for repo, entry in entries.items():
             entry = {} if entry is None else entry
+            # Keyed on the value's repr, so an unhashable one still compares
+            # and two files spelling it identically stay one value.
+            for key in PIN_KEYS if isinstance(entry, dict) else ():
+                if key in entry:
+                    pinned.setdefault((repo, key), {})[repr(entry[key])] = rel
             was = repos.get(repo)
             repos[repo] = ({**was, **entry}
                            if isinstance(was, dict) and isinstance(entry, dict)
                            else entry)
+
+    for (repo, key), values in sorted(pinned.items()):
+        if len(values) > 1:
+            return None, (f"{repo} is given more than one `{key}:` across the "
+                          "pin files ("
+                          + ", ".join(f"{f} -> {v}" for v, f
+                                      in sorted(values.items(),
+                                                key=lambda kv: kv[1]))
+                          + "), and which one kas would use is decided by an "
+                          "include chain this does not read")
 
     # Picking one of two chain defaults would resolve in silence a question
     # this cannot answer.

--- a/tools/layer-currency.py
+++ b/tools/layer-currency.py
@@ -60,11 +60,12 @@ def nested(doc, *keys):
 def load_pins(top: Path):
     """Every repo entry under includes/, or a refusal message.
 
-    Returns the entries merged by name as kas merges them -- a later file
-    adding layers to a repo an earlier one pinned is one entry, not two -- with
-    the branch an entry declaring none inherits, and the files read. An entry
-    that is not a mapping is carried through unmerged, for check() to refuse
-    rather than normalise."""
+    Returns the entries merged by name -- a later file adding layers to a repo
+    an earlier one pinned is one entry, not two -- with the branch an entry
+    declaring none inherits, and the files read. Merged in path order; where
+    two files set one repo's key that order decides it, which is not kas's
+    include-chain precedence. An entry that is not a mapping is carried through
+    unmerged, for check() to refuse rather than normalise."""
     root = top / INCLUDES
     files = sorted({p for g in PIN_GLOBS for p in root.rglob(g)}) \
         if root.is_dir() else []

--- a/tools/layer-currency.py
+++ b/tools/layer-currency.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Check the pinned upstream layers against the branch heads they track.
+"""Check the pinned upstream repositories against the branch heads they track.
 
     layer-currency.py check    -- which `commit:` pins upstream has moved past
 
@@ -12,29 +12,33 @@ import subprocess
 import sys
 from pathlib import Path
 
-import yaml
+try:
+    import yaml
+except ImportError:
+    yaml = None
 
-# Every file carrying a `commit:`. kas merges the repos dictionary across them,
-# so they are read as one; see docs/layers-and-kas.md.
-PIN_FILES = ("includes/base.yaml",
-             "includes/rauc.yaml",
-             "includes/platforms/raspberrypi.yaml")
-
-# The branch a repo declaring none inherits, and the file that sets it.
-DEFAULTS_FILE = "includes/base.yaml"
+# Where the pins live. Scanned rather than listed, so a pin added to a new
+# include file is covered the day it lands.
+INCLUDES = "includes"
+PIN_GLOBS = ("*.yaml", "*.yml")
 
 # A full object name. A short or symbolic pin is not comparable against what
 # ls-remote returns, and comparing it would report `behind` on spelling alone.
 SHA = re.compile(r"^[0-9a-f]{40}$")
 
+# Long enough for a slow remote, short enough that a stalled one is reported
+# rather than waited on.
+LS_REMOTE_TIMEOUT = 30
+
 BEHIND = "behind"
 CURRENT = "current"
 
 
-def repo_top() -> Path:
-    return Path(subprocess.run(["git", "rev-parse", "--show-toplevel"],
-                               capture_output=True, text=True,
-                               check=True).stdout.strip())
+def repo_top():
+    """The repository root, or None outside a work tree."""
+    run = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                         capture_output=True, text=True)
+    return Path(run.stdout.strip()) if run.returncode == 0 else None
 
 
 def refuse(message: str) -> int:
@@ -46,86 +50,144 @@ def tail(stream: str, lines: int = 3) -> str:
     return " / ".join(stream.strip().splitlines()[-lines:]) or "(no output)"
 
 
-def load_pins(top: Path):
-    """The repo entries from the pin files, and the branch they default to.
+def nested(doc, *keys):
+    """A value down a chain of mapping keys, or None if any hop is not one."""
+    for key in keys:
+        doc = doc.get(key) if isinstance(doc, dict) else None
+    return doc
 
-    Merged by name as kas merges them: a later file adding layers to a repo an
-    earlier one pinned is one entry, not two. An entry that is not a mapping is
-    carried through unmerged, for check() to refuse rather than normalise."""
-    repos, default_branch = {}, None
-    for name in PIN_FILES:
-        doc = yaml.safe_load((top / name).read_text())
-        doc = doc if isinstance(doc, dict) else {}
-        for repo, entry in (doc.get("repos") or {}).items():
+
+def load_pins(top: Path):
+    """Every repo entry under includes/, or a refusal message.
+
+    Returns the entries merged by name as kas merges them -- a later file
+    adding layers to a repo an earlier one pinned is one entry, not two -- with
+    the branch an entry declaring none inherits, and the files read. An entry
+    that is not a mapping is carried through unmerged, for check() to refuse
+    rather than normalise."""
+    root = top / INCLUDES
+    files = sorted({p for g in PIN_GLOBS for p in root.rglob(g)}) \
+        if root.is_dir() else []
+    if not files:
+        return None, (f"{INCLUDES}/ holds no YAML file, so no pin could be "
+                      "read")
+
+    repos, pin_files, defaults = {}, [], {}
+    for path in files:
+        rel = path.relative_to(top).as_posix()
+        try:
+            doc = yaml.safe_load(path.read_text())
+        except (yaml.YAMLError, OSError, UnicodeDecodeError) as exc:
+            return None, f"{rel} could not be parsed ({exc})"
+
+        branch = nested(doc, "defaults", "repos", "branch")
+        if branch is not None:
+            defaults[rel] = branch
+
+        entries = doc.get("repos") if isinstance(doc, dict) else None
+        if not isinstance(entries, dict):
+            continue
+        pin_files.append(rel)
+        for repo, entry in entries.items():
             entry = {} if entry is None else entry
             was = repos.get(repo)
             repos[repo] = ({**was, **entry}
                            if isinstance(was, dict) and isinstance(entry, dict)
                            else entry)
-        if name == DEFAULTS_FILE:
-            default_branch = (((doc.get("defaults") or {}).get("repos") or {})
-                              .get("branch"))
-    return repos, default_branch
+
+    # Picking one of two chain defaults would resolve in silence a question
+    # this cannot answer.
+    if len(set(defaults.values())) > 1:
+        return None, ("more than one chain default branch is set ("
+                      + ", ".join(f"{f} -> {b}"
+                                  for f, b in sorted(defaults.items()))
+                      + "), so no branch could be resolved")
+
+    return (repos, next(iter(defaults.values()), None), pin_files), None
 
 
 def ls_remote(url: str, branch: str):
     """The head of one branch at a remote, or a refusal message.
 
-    A hang is not a refusal, so both prompts are closed off: a url that has gone
-    private fails instead of blocking. GIT_TERMINAL_PROMPT alone leaves git
-    falling back to an SSH_ASKPASS helper, which on a host with a display waits
-    on a dialog nobody is watching."""
+    Both git prompts are closed off because a hang is not a refusal: a url that
+    has gone private fails instead of waiting on a credential nobody types."""
     ref = f"refs/heads/{branch}"
-    run = subprocess.run(["git", "ls-remote", url, ref],
-                         capture_output=True, text=True,
-                         env={**os.environ, "GIT_TERMINAL_PROMPT": "0",
-                              "GIT_ASKPASS": ""})
+    try:
+        run = subprocess.run(["git", "ls-remote", url, ref],
+                             capture_output=True, text=True,
+                             timeout=LS_REMOTE_TIMEOUT,
+                             env={**os.environ, "GIT_TERMINAL_PROMPT": "0",
+                                  "GIT_ASKPASS": ""})
+    except subprocess.TimeoutExpired:
+        return None, (f"`git ls-remote {url} {ref}` did not answer within "
+                      f"{LS_REMOTE_TIMEOUT}s")
     if run.returncode != 0:
         return None, (f"`git ls-remote {url} {ref}` failed "
                       f"({run.returncode}): {tail(run.stderr)}")
-    fields = run.stdout.split("\n", 1)[0].split()
-    if len(fields) != 2 or not SHA.match(fields[0]):
+
+    lines = run.stdout.strip().splitlines()
+    if not lines:
         return None, (f"{url} reports no {ref}, so this pin has no branch to "
                       "be compared against")
+    if len(lines) > 1:
+        return None, (f"{url} answers {ref} with {len(lines)} refs, so the "
+                      "head it names is ambiguous")
+
+    # The ref is compared, not assumed: ls-remote matches a ref TAIL, so a
+    # differently-named upstream branch can answer and be reported as this one.
+    fields = lines[0].split()
+    if len(fields) != 2 or not SHA.match(fields[0]) or fields[1] != ref:
+        return None, (f"{url} answers {ref} with {lines[0]!r}, which is not "
+                      "that ref at a full object name")
     return fields[0], None
 
 
 def check() -> int:
+    if yaml is None:
+        return refuse("python3 has no yaml module, so no pin could be parsed "
+                      "-- install PyYAML; the README prerequisites give a "
+                      "PEP-668-safe route")
     top = repo_top()
-    missing = [f for f in PIN_FILES if not (top / f).is_file()]
-    if missing:
-        return refuse(f"{', '.join(missing)} missing, so the pins could not "
-                      "be read")
+    if top is None:
+        return refuse("not inside a git work tree, so includes/ could not be "
+                      "located")
 
-    repos, default_branch = load_pins(top)
+    loaded, why = load_pins(top)
+    if why:
+        return refuse(why)
+    repos, default_branch, pin_files = loaded
+
     found, excluded = {BEHIND: [], CURRENT: []}, []
     for name, entry in sorted(repos.items()):
         if not isinstance(entry, dict):
             return refuse(f"the {name} entry is not a mapping, so its pin "
                           "could not be read")
 
-        url = entry.get("url")
-        if url is None:
-            # kas resolves a repo declaring no url to the repository holding
-            # the config file, so there is no upstream to ask.
+        url, commit = entry.get("url"), entry.get("commit")
+        if url is None and commit is None:
             excluded.append(name)
             continue
+        if url is None:
+            return refuse(f"{name} carries a `commit:` pin but no `url:`, so "
+                          "there is no remote to compare it against; the repo "
+                          "kas resolves to this repository carries neither")
         if not isinstance(url, str) or not url.strip():
             return refuse(f"the {name} entry declares a url of {url!r}, which "
                           "is not a remote that can be asked")
 
-        commit = entry.get("commit")
         if not isinstance(commit, str) or not SHA.match(commit):
+            typed = (" -- YAML types an unquoted all-digit sha as an integer"
+                     if isinstance(commit, int) else "")
             return refuse(f"{name} carries no full-length `commit:` pin "
-                          f"({commit!r}), so nothing could be compared "
+                          f"({commit!r}){typed}, so nothing could be compared "
                           f"against {url}")
 
         explicit = entry.get("branch")
         branch = explicit or default_branch
         if not isinstance(branch, str) or not branch.strip():
-            return refuse(f"{name} sets no `branch:` and {DEFAULTS_FILE} sets "
-                          "no defaults.repos.branch, so no branch could be "
-                          f"resolved for {url}")
+            return refuse(f"{name} sets no `branch:` and no file under "
+                          f"{INCLUDES}/ sets defaults.repos.branch, so no "
+                          f"branch could be resolved for {url}")
 
         head, why = ls_remote(url, branch)
         if why:
@@ -133,24 +195,29 @@ def check() -> int:
         found[BEHIND if head != commit else CURRENT].append(
             (name, branch, explicit is not None, commit, head, url))
 
+    # Every entry reading as the self repo means the discriminator stopped
+    # discriminating, which would empty the report without emptying the pins.
+    if len(excluded) > 1:
+        return refuse(f"{', '.join(sorted(excluded))} all carry neither `url:` "
+                      "nor `commit:`, and only one entry resolves to this "
+                      "repository")
     if not found[BEHIND] and not found[CURRENT]:
-        return refuse(f"{', '.join(PIN_FILES)} pin no upstream repository")
+        return refuse(f"{INCLUDES}/ pins no upstream repository")
 
     for status in (BEHIND, CURRENT):
         for name, branch, explicit, pin, head, url in found[status]:
-            # The branch a repo did not ask for by name is the inference worth
-            # seeing: it is what a wrong chain default would hide.
             where = branch if explicit else f"{branch} (chain default)"
             shas = f"{pin} -> {head}" if status == BEHIND else pin
             print(f"{status}  {name}  {where}  {shas}  {url}")
 
     total = len(found[BEHIND]) + len(found[CURRENT])
-    print(f"\n{len(found[BEHIND])} of {total} pinned layers behind the branch "
-          f"head they track, {len(found[CURRENT])} current")
+    print(f"\n{len(found[BEHIND])} of {total} pinned repositories behind the "
+          f"branch head they track, {len(found[CURRENT])} current")
     if excluded:
-        print(f"excluded: {', '.join(sorted(excluded))} -- no `url:`, so kas "
-              "resolves it to this repository and there is no pin to compare")
-    print(f"pins read from {', '.join(PIN_FILES)}")
+        print(f"excluded: {excluded[0]} -- neither `url:` nor `commit:`, so "
+              "kas resolves it to this repository and there is no pin to "
+              "compare")
+    print(f"pins read from {', '.join(pin_files)}")
     print("`behind` says the head has moved off the pin, not that the pin is "
           "unsafe; what those commits carry is a separate read. "
           "See docs/layer-currency.md.")

--- a/tools/layer-currency.py
+++ b/tools/layer-currency.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Check the pinned upstream layers against the branch heads they track.
+
+    layer-currency.py check    -- which `commit:` pins upstream has moved past
+
+The pins come from includes/, and each remote is asked directly: no build and no
+checkout, network only. See docs/layer-currency.md.
+"""
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+# Every file carrying a `commit:`. kas merges the repos dictionary across them,
+# so they are read as one; see docs/layers-and-kas.md.
+PIN_FILES = ("includes/base.yaml",
+             "includes/rauc.yaml",
+             "includes/platforms/raspberrypi.yaml")
+
+# The branch a repo declaring none inherits, and the file that sets it.
+DEFAULTS_FILE = "includes/base.yaml"
+
+# A full object name. A short or symbolic pin is not comparable against what
+# ls-remote returns, and comparing it would report `behind` on spelling alone.
+SHA = re.compile(r"^[0-9a-f]{40}$")
+
+BEHIND = "behind"
+CURRENT = "current"
+
+
+def repo_top() -> Path:
+    return Path(subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                               capture_output=True, text=True,
+                               check=True).stdout.strip())
+
+
+def refuse(message: str) -> int:
+    print(f"{message} -- refusing to report a pass", file=sys.stderr)
+    return 2
+
+
+def tail(stream: str, lines: int = 3) -> str:
+    return " / ".join(stream.strip().splitlines()[-lines:]) or "(no output)"
+
+
+def load_pins(top: Path):
+    """The repo entries from the pin files, and the branch they default to.
+
+    Merged by name as kas merges them: a later file adding layers to a repo an
+    earlier one pinned is one entry, not two. An entry that is not a mapping is
+    carried through unmerged, for check() to refuse rather than normalise."""
+    repos, default_branch = {}, None
+    for name in PIN_FILES:
+        doc = yaml.safe_load((top / name).read_text())
+        doc = doc if isinstance(doc, dict) else {}
+        for repo, entry in (doc.get("repos") or {}).items():
+            entry = {} if entry is None else entry
+            was = repos.get(repo)
+            repos[repo] = ({**was, **entry}
+                           if isinstance(was, dict) and isinstance(entry, dict)
+                           else entry)
+        if name == DEFAULTS_FILE:
+            default_branch = (((doc.get("defaults") or {}).get("repos") or {})
+                              .get("branch"))
+    return repos, default_branch
+
+
+def ls_remote(url: str, branch: str):
+    """The head of one branch at a remote, or a refusal message.
+
+    A hang is not a refusal, so both prompts are closed off: a url that has gone
+    private fails instead of blocking. GIT_TERMINAL_PROMPT alone leaves git
+    falling back to an SSH_ASKPASS helper, which on a host with a display waits
+    on a dialog nobody is watching."""
+    ref = f"refs/heads/{branch}"
+    run = subprocess.run(["git", "ls-remote", url, ref],
+                         capture_output=True, text=True,
+                         env={**os.environ, "GIT_TERMINAL_PROMPT": "0",
+                              "GIT_ASKPASS": ""})
+    if run.returncode != 0:
+        return None, (f"`git ls-remote {url} {ref}` failed "
+                      f"({run.returncode}): {tail(run.stderr)}")
+    fields = run.stdout.split("\n", 1)[0].split()
+    if len(fields) != 2 or not SHA.match(fields[0]):
+        return None, (f"{url} reports no {ref}, so this pin has no branch to "
+                      "be compared against")
+    return fields[0], None
+
+
+def check() -> int:
+    top = repo_top()
+    missing = [f for f in PIN_FILES if not (top / f).is_file()]
+    if missing:
+        return refuse(f"{', '.join(missing)} missing, so the pins could not "
+                      "be read")
+
+    repos, default_branch = load_pins(top)
+    found, excluded = {BEHIND: [], CURRENT: []}, []
+    for name, entry in sorted(repos.items()):
+        if not isinstance(entry, dict):
+            return refuse(f"the {name} entry is not a mapping, so its pin "
+                          "could not be read")
+
+        url = entry.get("url")
+        if url is None:
+            # kas resolves a repo declaring no url to the repository holding
+            # the config file, so there is no upstream to ask.
+            excluded.append(name)
+            continue
+        if not isinstance(url, str) or not url.strip():
+            return refuse(f"the {name} entry declares a url of {url!r}, which "
+                          "is not a remote that can be asked")
+
+        commit = entry.get("commit")
+        if not isinstance(commit, str) or not SHA.match(commit):
+            return refuse(f"{name} carries no full-length `commit:` pin "
+                          f"({commit!r}), so nothing could be compared "
+                          f"against {url}")
+
+        explicit = entry.get("branch")
+        branch = explicit or default_branch
+        if not isinstance(branch, str) or not branch.strip():
+            return refuse(f"{name} sets no `branch:` and {DEFAULTS_FILE} sets "
+                          "no defaults.repos.branch, so no branch could be "
+                          f"resolved for {url}")
+
+        head, why = ls_remote(url, branch)
+        if why:
+            return refuse(why)
+        found[BEHIND if head != commit else CURRENT].append(
+            (name, branch, explicit is not None, commit, head, url))
+
+    if not found[BEHIND] and not found[CURRENT]:
+        return refuse(f"{', '.join(PIN_FILES)} pin no upstream repository")
+
+    for status in (BEHIND, CURRENT):
+        for name, branch, explicit, pin, head, url in found[status]:
+            # The branch a repo did not ask for by name is the inference worth
+            # seeing: it is what a wrong chain default would hide.
+            where = branch if explicit else f"{branch} (chain default)"
+            shas = f"{pin} -> {head}" if status == BEHIND else pin
+            print(f"{status}  {name}  {where}  {shas}  {url}")
+
+    total = len(found[BEHIND]) + len(found[CURRENT])
+    print(f"\n{len(found[BEHIND])} of {total} pinned layers behind the branch "
+          f"head they track, {len(found[CURRENT])} current")
+    if excluded:
+        print(f"excluded: {', '.join(sorted(excluded))} -- no `url:`, so kas "
+              "resolves it to this repository and there is no pin to compare")
+    print(f"pins read from {', '.join(PIN_FILES)}")
+    print("`behind` says the head has moved off the pin, not that the pin is "
+          "unsafe; what those commits carry is a separate read. "
+          "See docs/layer-currency.md.")
+
+    # Reports, never gates: exit 0 with findings. A nonzero exit is reserved for
+    # a report that cannot be trusted. See docs/layer-currency.md.
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) == 2 and sys.argv[1] == "check":
+        return check()
+    print(__doc__.strip().split("\n\n")[1], file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #72 (Leg D of epic #61).

## What this ships

A locally-runnable "Dependabot for the BitBake layers." Dependabot is blind to the image's real
inputs — the upstream repos frozen at a `commit:` in `includes/` — and `.github/dependabot.yml` says
so. `just currency` (`tools/layer-currency.py check`) closes that gap: for every pinned upstream
repo it `git ls-remote`s the branch it tracks and reports **current** or **behind**, with both SHAs,
the branch used, and the repo URL. Read-only, no build, no container, no `kas` — so guard 10 never
arms — and it reports, never gates.

## Scope (re-scoped with the owner)

The ticket title floats AUH / `devtool check-upgrade-status`, but those inspect *recipes inside* a
frozen layer, not the layer **pins** the ticket body names — and on `scarthgap` (LTS) they are
structurally noisy. This PR delivers the layer-pin currency the body asks for, the highest-value
read-only signal (it already flags poky, meta-openembedded and meta-virtualization behind, and
poky's gap includes an openssh CVE-status commit). **AUH is dropped** (wrong actor for this repo).
Two follow-ups carry the rest:

- **#81** — investigate a scoped `devtool check-upgrade-status` recipe-currency target once the LTS
  noise can be muted.
- **#80** — triage the findings (bump the stale pins); blocked-by this issue.

## Design

- **Targets are discovered, not hardcoded.** The tool `rglob`s `includes/` for every file carrying a
  `repos:` block and merges the pins by name — matching the repo's own `grep -rn 'commit:' includes/`
  enumerator. A repo (or a whole new include file) added tomorrow is covered with no code change.
- **Branch** = the repo's explicit `branch:`, else the `defaults.repos.branch: scarthgap` chain
  default (printed as `(chain default)` so the inference is visible).
- **Outcomes:** no skipped state. It **refuses (exit 2)** on anything it cannot resolve — a pin with
  no `url:`, missing PyYAML, malformed YAML, an `ls-remote` failure or 30 s stall, a tail-matched
  wrong ref, or a repo pinned conflictingly across two files — and exits 0 with findings otherwise.
  A layer is never silently dropped.

## Verification

- Oracle: `3 of 9 pinned repositories behind` (poky, meta-openembedded, meta-virtualization), 6
  current; `meta-autonomos` resolves once on `main`.
- Prove-it-can-fail seeds for every refusal path (dropped `url:`, stale/new pin, corrupt YAML,
  no-PyYAML, tail-match, cross-file conflict), each confirmed to land and revert.
- `just guards` (guard 10 green), `just links` / `just verify`, and `just currency` end-to-end all
  pass. Three independent review passes; all findings closed, no regression.

## Known, non-blocking

Merge is by repo name across the `includes/` files; the tool does not replicate kas's include-chain
precedence, so it **refuses** on a cross-file pin conflict rather than guess. `PIN_KEYS` covers
`url`/`commit`/`branch` (kas's `tag:`/`refspec:` are unused here). Recipe-version currency and the
`PREFERRED_VERSION_linux-raspberrypi` 6.6-vs-6.12 kernel axis (where most of the CVE mass sits) are
out of scope — the first is #81, the second is a decision, not a currency report.
